### PR TITLE
[Usability] Auto-add Administrator user to the Print group

### DIFF
--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -3,6 +3,7 @@
   <data noupdate="1">
     <record id="res_groups_printingprintoperator0" model="res.groups">
       <field name="name">Printing / Print Operator</field>
+      <field name="users" eval="[(4, ref('base.user_root'))]"/>
     </record>
     <record id="ir_model_access_printingprintergroup1" model="ir.model.access">
       <field name="name">printing_printer group</field>


### PR DESCRIPTION
This PR will automatically add the Administrator user to the Print group, which is quite convenient. A lot of modules do that !
It also cleans up the XML code by removing the ugly "&quot;&quot;&quot;"
