### PR TITLE
Do no longer returns a PDF when a report is printed

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -5,7 +5,7 @@ This module allows users to send reports to a printer attached to the server.
 
 It adds an optional behaviour on reports to send it directly to a printer.
 
-* `Send to Client` is the default behavious providing you a downloadable PDF
+* `Send to Client` is the default behaviour providing you a downloadable PDF
 * `Send to Printer` prints the report on selected printer
 
 Report behaviour is defined by settings.
@@ -23,13 +23,18 @@ After installing enable the "Printing / Print Operator" option under access
 rights to give users the ability to view the print menu.
 
 
-To show all available printers for your server, uses
+To show all available printers for your server, use the
 `Settings/Configuration/Printing/Update Printers from CUPS` wizard.
 
 
-Then goto the user profile and set the users printing action and default
+Then go to the user profile and set the users printing action and default
 printer.
 
+Caveat
+------
+
+The notification when a report is sent to a printer will not be
+displayed for the deprecated report types (RML, Webkit, ...).
 
 Dependencies
 ------------

--- a/base_report_to_printer/__openerp__.py
+++ b/base_report_to_printer/__openerp__.py
@@ -35,6 +35,7 @@
         'security/security.xml',
         'printing_data.xml',
         'printing_view.xml',
+        'base_report_to_printer.xml',
         'wizard/update_printers.xml',
     ],
     'installable': True,

--- a/base_report_to_printer/base_report_to_printer.xml
+++ b/base_report_to_printer/base_report_to_printer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="base_report_to_printer assets" inherit_id="report.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/base_report_to_printer/static/src/js/qwebactionmanager.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>
+

--- a/base_report_to_printer/i18n/base_report_to_printer.pot
+++ b/base_report_to_printer/i18n/base_report_to_printer.pot
@@ -1,16 +1,15 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* base_report_to_printer
+#	* base_report_to_printer
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 14:48+0000\n"
-"PO-Revision-Date: 2014-11-17 12:50+0000\n"
+"POT-Creation-Date: 2015-01-21 14:44+0000\n"
+"PO-Revision-Date: 2015-01-21 14:44+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -38,16 +37,22 @@ msgid "Cancel"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,create_uid:0 field:printing.printer,create_uid:0
-#: field:printing.printer.polling,create_uid:0
+#: code:addons/base_report_to_printer/wizard/update_printers.py:50
+#, python-format
+msgid "Could not get the list of printers from the CUPS server (%s:%s)"
+msgstr ""
+
+#. module: base_report_to_printer
+#: field:printing.action,create_uid:0
+#: field:printing.printer,create_uid:0
 #: field:printing.printer.update.wizard,create_uid:0
 #: field:printing.report.xml.action,create_uid:0
 msgid "Created by"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,create_date:0 field:printing.printer,create_date:0
-#: field:printing.printer.polling,create_date:0
+#: field:printing.action,create_date:0
+#: field:printing.printer,create_date:0
 #: field:printing.printer.update.wizard,create_date:0
 #: field:printing.report.xml.action,create_date:0
 msgid "Created on"
@@ -64,37 +69,52 @@ msgid "Default Printer"
 msgstr ""
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:27
+#, python-format
+msgid "Document sent to the printer "
+msgstr ""
+
+#. module: base_report_to_printer
 #: selection:printing.printer,status:0
 msgid "Error"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,id:0 field:printing.printer,id:0
-#: field:printing.printer.polling,id:0
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:30
+#, python-format
+msgid "Error when sending the document to the printer "
+msgstr ""
+
+#. module: base_report_to_printer
+#: code:addons/base_report_to_printer/printing.py:140
+#, python-format
+msgid "Failed to connect to the CUPS server on %s:%s. Check that the CUPS server is running and that you can reach it from the Odoo server."
+msgstr ""
+
+#. module: base_report_to_printer
+#: field:printing.action,id:0
+#: field:printing.printer,id:0
 #: field:printing.printer.update.wizard,id:0
 #: field:printing.report.xml.action,id:0
 msgid "ID"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,write_uid:0 field:printing.printer,write_uid:0
-#: field:printing.printer.polling,write_uid:0
+#: field:printing.action,write_uid:0
+#: field:printing.printer,write_uid:0
 #: field:printing.printer.update.wizard,write_uid:0
 #: field:printing.report.xml.action,write_uid:0
 msgid "Last Updated by"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,write_date:0 field:printing.printer,write_date:0
-#: field:printing.printer.polling,write_date:0
+#: field:printing.action,write_date:0
+#: field:printing.printer,write_date:0
 #: field:printing.printer.update.wizard,write_date:0
 #: field:printing.report.xml.action,write_date:0
 msgid "Last Updated on"
-msgstr ""
-
-#. module: base_report_to_printer
-#: field:printing.printer.polling,last_update:0
-msgid "Last update"
 msgstr ""
 
 #. module: base_report_to_printer
@@ -108,8 +128,15 @@ msgid "Model"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.action,name:0 field:printing.printer,name:0
+#: field:printing.action,name:0
+#: field:printing.printer,name:0
 msgid "Name"
+msgstr ""
+
+#. module: base_report_to_printer
+#: code:addons/base_report_to_printer/ir_report.py:114
+#, python-format
+msgid "No printer configured to print this report."
 msgstr ""
 
 #. module: base_report_to_printer
@@ -143,11 +170,6 @@ msgid "Printers"
 msgstr ""
 
 #. module: base_report_to_printer
-#: model:ir.model,name:base_report_to_printer.model_printing_printer_polling
-msgid "Printers Polling"
-msgstr ""
-
-#. module: base_report_to_printer
 #: model:ir.ui.menu,name:base_report_to_printer.menu_printing_main
 #: selection:printing.printer,status:0
 #: view:res.users:base_report_to_printer.view_printing_users_prefs
@@ -165,8 +187,12 @@ msgid "Printing action"
 msgstr ""
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:26
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:29
 #: model:ir.model,name:base_report_to_printer.model_report
 #: field:printing.report.xml.action,report_id:0
+#, python-format
 msgid "Report"
 msgstr ""
 
@@ -229,14 +255,17 @@ msgstr ""
 
 #. module: base_report_to_printer
 #: view:printing.printer.update.wizard:base_report_to_printer.printer_update_wizard
-msgid ""
-"This process will create all the missing printers from the current CUPS "
-"server."
+msgid "This process will create all missing printers from the current CUPS server."
 msgstr ""
 
 #. module: base_report_to_printer
 #: field:printing.action,type:0
 msgid "Type"
+msgstr ""
+
+#. module: base_report_to_printer
+#: field:printing.printer,uri:0
+msgid "URI"
 msgstr ""
 
 #. module: base_report_to_printer
@@ -257,11 +286,6 @@ msgid "Update Printers from CUPS"
 msgstr ""
 
 #. module: base_report_to_printer
-#: field:printing.printer,uri:0
-msgid "URI"
-msgstr ""
-
-#. module: base_report_to_printer
 #: field:printing.report.xml.action,user_id:0
 msgid "User"
 msgstr ""
@@ -270,3 +294,9 @@ msgstr ""
 #: model:ir.model,name:base_report_to_printer.model_res_users
 msgid "Users"
 msgstr ""
+
+#. module: base_report_to_printer
+#: view:printing.printer.update.wizard:base_report_to_printer.printer_update_wizard
+msgid "or"
+msgstr ""
+

--- a/base_report_to_printer/i18n/fr.po
+++ b/base_report_to_printer/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-05 14:48+0000\n"
+"POT-Creation-Date: 2015-01-21 14:44+0000\n"
 "PO-Revision-Date: 2014-02-25 15:06+0000\n"
 "Last-Translator: Guewen Baconnier @ Camptocamp <Unknown>\n"
 "Language-Team: \n"
@@ -39,8 +39,13 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #. module: base_report_to_printer
+#: code:addons/base_report_to_printer/wizard/update_printers.py:50
+#, python-format
+msgid "Could not get the list of printers from the CUPS server (%s:%s)"
+msgstr "Impossible d'obtenir la liste des imprimantes depuis le serveur CUPS (%s:%s)"
+
+#. module: base_report_to_printer
 #: field:printing.action,create_uid:0 field:printing.printer,create_uid:0
-#: field:printing.printer.polling,create_uid:0
 #: field:printing.printer.update.wizard,create_uid:0
 #: field:printing.report.xml.action,create_uid:0
 msgid "Created by"
@@ -48,7 +53,6 @@ msgstr ""
 
 #. module: base_report_to_printer
 #: field:printing.action,create_date:0 field:printing.printer,create_date:0
-#: field:printing.printer.polling,create_date:0
 #: field:printing.printer.update.wizard,create_date:0
 #: field:printing.report.xml.action,create_date:0
 msgid "Created on"
@@ -65,13 +69,35 @@ msgid "Default Printer"
 msgstr "Imprimante par défaut"
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:27
+#, python-format
+msgid "Document sent to the printer "
+msgstr "Document envoyé à l'imprimante "
+
+#. module: base_report_to_printer
 #: selection:printing.printer,status:0
 msgid "Error"
 msgstr "Erreur"
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:30
+#, python-format
+msgid "Error when sending the document to the printer "
+msgstr "Erreur lors de l'envoi du document à l'imprimante "
+
+#. module: base_report_to_printer
+#: code:addons/base_report_to_printer/printing.py:140
+#, python-format
+msgid ""
+"Failed to connect to the CUPS server on %s:%s. Check that the CUPS server is "
+"running and that you can reach it from the Odoo server."
+msgstr "La connexion au serveur CUPS %s:%s a échoué. Veuillez contrôler que le "
+"serveur soit démarré et qu'il soit atteignable depuis le serveur Odoo. "
+
+#. module: base_report_to_printer
 #: field:printing.action,id:0 field:printing.printer,id:0
-#: field:printing.printer.polling,id:0
 #: field:printing.printer.update.wizard,id:0
 #: field:printing.report.xml.action,id:0
 msgid "ID"
@@ -79,7 +105,6 @@ msgstr ""
 
 #. module: base_report_to_printer
 #: field:printing.action,write_uid:0 field:printing.printer,write_uid:0
-#: field:printing.printer.polling,write_uid:0
 #: field:printing.printer.update.wizard,write_uid:0
 #: field:printing.report.xml.action,write_uid:0
 msgid "Last Updated by"
@@ -87,15 +112,9 @@ msgstr ""
 
 #. module: base_report_to_printer
 #: field:printing.action,write_date:0 field:printing.printer,write_date:0
-#: field:printing.printer.polling,write_date:0
 #: field:printing.printer.update.wizard,write_date:0
 #: field:printing.report.xml.action,write_date:0
 msgid "Last Updated on"
-msgstr ""
-
-#. module: base_report_to_printer
-#: field:printing.printer.polling,last_update:0
-msgid "Last update"
 msgstr ""
 
 #. module: base_report_to_printer
@@ -112,6 +131,12 @@ msgstr "Modèle"
 #: field:printing.action,name:0 field:printing.printer,name:0
 msgid "Name"
 msgstr "Nom"
+
+#. module: base_report_to_printer
+#: code:addons/base_report_to_printer/ir_report.py:114
+#, python-format
+msgid "No printer configured to print this report."
+msgstr "Pas d'imprimante configurée pour imprimer ce rapport."
 
 #. module: base_report_to_printer
 #: view:res.users:base_report_to_printer.view_printing_users_form
@@ -144,11 +169,6 @@ msgid "Printers"
 msgstr "Imprimantes"
 
 #. module: base_report_to_printer
-#: model:ir.model,name:base_report_to_printer.model_printing_printer_polling
-msgid "Printers Polling"
-msgstr "Recherche d'imprimantes"
-
-#. module: base_report_to_printer
 #: model:ir.ui.menu,name:base_report_to_printer.menu_printing_main
 #: selection:printing.printer,status:0
 #: view:res.users:base_report_to_printer.view_printing_users_prefs
@@ -166,8 +186,12 @@ msgid "Printing action"
 msgstr "Action d'impression"
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:26
+#: code:addons/base_report_to_printer/static/src/js/qwebactionmanager.js:29
 #: model:ir.model,name:base_report_to_printer.model_report
 #: field:printing.report.xml.action,report_id:0
+#, python-format
 msgid "Report"
 msgstr "Rapport"
 
@@ -232,8 +256,7 @@ msgstr ""
 #. module: base_report_to_printer
 #: view:printing.printer.update.wizard:base_report_to_printer.printer_update_wizard
 msgid ""
-"This process will create all the missing printers from the current CUPS "
-"server."
+"This process will create all missing printers from the current CUPS server."
 msgstr ""
 "Cette opération va créer les imprimantes manquantes à partir du serveur CUPS "
 "courant."
@@ -242,6 +265,11 @@ msgstr ""
 #: field:printing.action,type:0
 msgid "Type"
 msgstr "Type"
+
+#. module: base_report_to_printer
+#: field:printing.printer,uri:0
+msgid "URI"
+msgstr ""
 
 #. module: base_report_to_printer
 #: selection:printing.printer,status:0
@@ -261,11 +289,6 @@ msgid "Update Printers from CUPS"
 msgstr "Mettre à jour les imprimantes depuis CUPS"
 
 #. module: base_report_to_printer
-#: field:printing.printer,uri:0
-msgid "URI"
-msgstr ""
-
-#. module: base_report_to_printer
 #: field:printing.report.xml.action,user_id:0
 msgid "User"
 msgstr "Utilisateur"
@@ -274,3 +297,8 @@ msgstr "Utilisateur"
 #: model:ir.model,name:base_report_to_printer.model_res_users
 msgid "Users"
 msgstr "Utilisateurs"
+
+#. module: base_report_to_printer
+#: view:printing.printer.update.wizard:base_report_to_printer.printer_update_wizard
+msgid "or"
+msgstr "ou"

--- a/base_report_to_printer/ir_report.py
+++ b/base_report_to_printer/ir_report.py
@@ -52,6 +52,23 @@ class ReportXml(models.Model):
              'user basis'
     )
 
+    @api.model
+    def print_action_for_report_name(self, report_name):
+        """ Returns if the action is a direct print or pdf
+
+        Called from js
+        """
+        report_obj = self.env['report']
+        report = report_obj._get_report_from_name(report_name)
+        if not report:
+            return {}
+        result = report.behaviour()[report.id]
+        serializable_result = {
+            'action': result['action'],
+            'printer_name': result['printer'].name,
+        }
+        return serializable_result
+
     @api.multi
     def behaviour(self):
         result = {}

--- a/base_report_to_printer/ir_report.py
+++ b/base_report_to_printer/ir_report.py
@@ -23,7 +23,7 @@
 ##############################################################################
 import logging
 
-from openerp import models, fields, api
+from openerp import models, fields, api, exceptions, _
 
 _logger = logging.getLogger('base_report_to_printer')
 
@@ -62,7 +62,7 @@ class ReportXml(models.Model):
         report = report_obj._get_report_from_name(report_name)
         if not report:
             return {}
-        result = report.behaviour()[report.id]
+        result = report.behaviour(raise_if_no_printer=False)[report.id]
         serializable_result = {
             'action': result['action'],
             'printer_name': result['printer'].name,
@@ -70,7 +70,7 @@ class ReportXml(models.Model):
         return serializable_result
 
     @api.multi
-    def behaviour(self):
+    def behaviour(self, raise_if_no_printer=True):
         result = {}
         printer_obj = self.env['printing.printer']
         printing_act_obj = self.env['printing.report.xml.action']
@@ -109,6 +109,10 @@ class ReportXml(models.Model):
                 if user_action['printer']:
                     printer = user_action['printer']
 
+            if not printer and raise_if_no_printer:
+                raise exceptions.Warning(
+                    _('No printer configured to print this report.')
+                )
             result[report.id] = {'action': action,
                                  'printer': printer,
                                  }

--- a/base_report_to_printer/ir_report.py
+++ b/base_report_to_printer/ir_report.py
@@ -23,7 +23,7 @@
 ##############################################################################
 import logging
 
-from openerp import models, fields, api, exceptions, _
+from openerp import models, fields, api
 
 _logger = logging.getLogger('base_report_to_printer')
 
@@ -62,7 +62,7 @@ class ReportXml(models.Model):
         report = report_obj._get_report_from_name(report_name)
         if not report:
             return {}
-        result = report.behaviour(raise_if_no_printer=False)[report.id]
+        result = report.behaviour()[report.id]
         serializable_result = {
             'action': result['action'],
             'printer_name': result['printer'].name,
@@ -70,7 +70,7 @@ class ReportXml(models.Model):
         return serializable_result
 
     @api.multi
-    def behaviour(self, raise_if_no_printer=True):
+    def behaviour(self):
         result = {}
         printer_obj = self.env['printing.printer']
         printing_act_obj = self.env['printing.report.xml.action']
@@ -109,10 +109,6 @@ class ReportXml(models.Model):
                 if user_action['printer']:
                     printer = user_action['printer']
 
-            if not printer and raise_if_no_printer:
-                raise exceptions.Warning(
-                    _('No printer configured to print this report.')
-                )
             result[report.id] = {'action': action,
                                  'printer': printer,
                                  }

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-from openerp import models
+from openerp import models, exceptions, _
 
 
 class Report(models.Model):
@@ -34,6 +34,10 @@ class Report(models.Model):
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
+        if not printer:
+            raise exceptions.Warning(
+                _('No printer configured to print this report.')
+            )
         return printer.print_document(report, document, report.report_type)
 
     def get_pdf(self, cr, uid, ids, report_name, html=None,
@@ -48,7 +52,7 @@ class Report(models.Model):
                                                context=context)
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
-        if behaviour['action'] == 'server' and document:
-            printer = behaviour['printer']
+        printer = behaviour['printer']
+        if behaviour['action'] == 'server' and printer and document:
             printer.print_document(report, document, report.report_type)
         return document

--- a/base_report_to_printer/static/src/js/qwebactionmanager.js
+++ b/base_report_to_printer/static/src/js/qwebactionmanager.js
@@ -1,0 +1,43 @@
+openerp.base_report_to_printer = function(instance) {
+
+    instance.web.ActionManager.include({
+        ir_actions_report_xml: function(action, options) {
+            instance.web.blockUI();
+            action = _.clone(action);
+            var _t =  instance.web._t;
+            var self = this;
+            var _super = this._super;
+
+            if ('report_type' in action && action.report_type === 'qweb-pdf') {
+                new instance.web.Model('ir.actions.report.xml')
+                    .call('print_action_for_report_name', [action.report_name])
+                    .then(function(print_action){
+                        if (print_action && print_action['action'] === 'server') {
+                            instance.web.unblockUI();
+                            new instance.web.Model('report')
+                                .call('print_document',
+                                      [action.context.active_ids,
+                                       action.report_name,
+                                       ],
+                                      {data: action.data || {},
+                                       context: action.context || {},
+                                       })
+                                .then(function(result){
+                                    self.do_notify(_t('Report'),
+                                                   _t('Document sent to the printer ') + print_action.printer_name);
+                                }).fail(function() {
+                                    self.do_notify(_t('Report'),
+                                                   _t('Error when sending the document to the printer ') + print_action.printer_name);
+
+                                });
+                        } else {
+                            return _super.apply(self, [action, options]);
+                        }
+                    });
+            } else {
+                return _super.apply(self, [action, options]);
+            }
+        }
+    });
+};
+

--- a/printer_tray/report_xml_action.py
+++ b/printer_tray/report_xml_action.py
@@ -32,9 +32,11 @@ class ReportXMLAction(models.Model):
     )
 
     @api.multi
-    def behaviour(self):
+    def behaviour(self, raise_if_no_printer=True):
         self.ensure_one()
-        res = super(ReportXMLAction, self).behaviour()
+        res = super(ReportXMLAction, self).behaviour(
+            raise_if_no_printer=raise_if_no_printer
+        )
         res['tray'] = self.printer_tray_id.system_name
         return res
 

--- a/printer_tray/report_xml_action.py
+++ b/printer_tray/report_xml_action.py
@@ -32,11 +32,9 @@ class ReportXMLAction(models.Model):
     )
 
     @api.multi
-    def behaviour(self, raise_if_no_printer=True):
+    def behaviour(self):
         self.ensure_one()
-        res = super(ReportXMLAction, self).behaviour(
-            raise_if_no_printer=raise_if_no_printer
-        )
+        res = super(ReportXMLAction, self).behaviour()
         res['tray'] = self.printer_tray_id.system_name
         return res
 


### PR DESCRIPTION
Instead, a notification is displayed to the user. When report.get_pdf() is
called on a report that must be printer, it will print the report _and_
returns the pdf, thus code that calls directly report.get_pdf() will print
the pdf on the printer as expected.

Fixes #16
