### PR TITLE
Compatibility fix for report with custom parser

### DIFF
--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -50,9 +50,7 @@ class Report(models.Model):
         If you want to prevent `get_pdf` to send report you can set
         the `must_skip_send_to_printer` key to True in the context
         """
-        if context is None:
-            context = self.pool['res.users'].context_get(cr, uid)
-        if context.get('must_skip_send_to_printer'):
+        if context is not None and context.get('must_skip_send_to_printer'):
             return False
         if behaviour['action'] == 'server' and printer and document:
             return True

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -25,12 +25,26 @@ from openerp import models, exceptions, _
 class Report(models.Model):
     _inherit = 'report'
 
+    def _can_send_report(self, cr, uid, ids, behaviour, printer, document,
+                         context=None):
+        """Predicate that decide if report can be sent to printer
+
+        If you want to prevent `get_pdf` to send report you can set
+        the `must_skip_sent_to_printer` key to True in the context
+        """
+        if context is None:
+            context = self.pool['res.users'].context_get(cr, uid)
+        if context.get('must_skip_sent_to_printer'):
+            return False
+        if behaviour['action'] == 'server' and printer and document:
+            return True
+        return False
+
     def print_document(self, cr, uid, ids, report_name, html=None,
                        data=None, context=None):
         """ Print a document, do not return the document file """
-        document = super(Report, self).get_pdf(cr, uid, ids, report_name,
-                                               html=html, data=data,
-                                               context=context)
+        document = self.get_pdf(cr, uid, ids, report_name,
+                                html=html, data=data, context=context)
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
@@ -47,12 +61,19 @@ class Report(models.Model):
         If the action configured on the report is server, it prints the
         generated document as well.
         """
+        if context is None:
+            context = self.pool['res.users'].context_get(cr, uid)
         document = super(Report, self).get_pdf(cr, uid, ids, report_name,
                                                html=html, data=data,
                                                context=context)
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
-        if behaviour['action'] == 'server' and printer and document:
-            printer.print_document(report, document, report.report_type)
+        can_send_report = self._can_send_report(cr, uid, ids,
+                                                behaviour, printer, document,
+                                                context=context)
+        if can_send_report:
+            sent = printer.print_document(report, document, report.report_type)
+            context['must_skip_sent_to_printer'] = True
+            return sent
         return document

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -43,8 +43,12 @@ class Report(models.Model):
     def print_document(self, cr, uid, ids, report_name, html=None,
                        data=None, context=None):
         """ Print a document, do not return the document file """
+        if context is None:
+            context = self.pool['res.users'].context_get(cr, uid)
+        local_context = dict(context)
+        local_context['must_skip_sent_to_printer'] = True
         document = self.get_pdf(cr, uid, ids, report_name,
-                                html=html, data=data, context=context)
+                                html=html, data=data, context=local_context)
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
@@ -73,7 +77,6 @@ class Report(models.Model):
                                                 behaviour, printer, document,
                                                 context=context)
         if can_send_report:
-            sent = printer.print_document(report, document, report.report_type)
+            printer.print_document(report, document, report.report_type)
             context['must_skip_sent_to_printer'] = True
-            return sent
         return document

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -25,21 +25,6 @@ from openerp import models, exceptions, _
 class Report(models.Model):
     _inherit = 'report'
 
-    def _can_send_report(self, cr, uid, ids, behaviour, printer, document,
-                         context=None):
-        """Predicate that decide if report can be sent to printer
-
-        If you want to prevent `get_pdf` to send report you can set
-        the `must_skip_send_to_printer` key to True in the context
-        """
-        if context is None:
-            context = self.pool['res.users'].context_get(cr, uid)
-        if context.get('must_skip_send_to_printer'):
-            return False
-        if behaviour['action'] == 'server' and printer and document:
-            return True
-        return False
-
     def print_document(self, cr, uid, ids, report_name, html=None,
                        data=None, context=None):
         """ Print a document, do not return the document file """
@@ -58,6 +43,21 @@ class Report(models.Model):
             )
         return printer.print_document(report, document, report.report_type)
 
+    def _can_print_report(self, cr, uid, ids, behaviour, printer, document,
+                          context=None):
+        """Predicate that decide if report can be sent to printer
+
+        If you want to prevent `get_pdf` to send report you can set
+        the `must_skip_send_to_printer` key to True in the context
+        """
+        if context is None:
+            context = self.pool['res.users'].context_get(cr, uid)
+        if context.get('must_skip_send_to_printer'):
+            return False
+        if behaviour['action'] == 'server' and printer and document:
+            return True
+        return False
+
     def get_pdf(self, cr, uid, ids, report_name, html=None,
                 data=None, context=None):
         """ Generate a PDF and returns it.
@@ -71,9 +71,9 @@ class Report(models.Model):
         report = self._get_report_from_name(cr, uid, report_name)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
-        can_send_report = self._can_send_report(cr, uid, ids,
-                                                behaviour, printer, document,
-                                                context=context)
-        if can_send_report:
+        can_print_report = self._can_print_report(cr, uid, ids,
+                                                  behaviour, printer, document,
+                                                  context=context)
+        if can_print_report:
             printer.print_document(report, document, report.report_type)
         return document

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -30,11 +30,11 @@ class Report(models.Model):
         """Predicate that decide if report can be sent to printer
 
         If you want to prevent `get_pdf` to send report you can set
-        the `must_skip_sent_to_printer` key to True in the context
+        the `must_skip_send_to_printer` key to True in the context
         """
         if context is None:
             context = self.pool['res.users'].context_get(cr, uid)
-        if context.get('must_skip_sent_to_printer'):
+        if context.get('must_skip_send_to_printer'):
             return False
         if behaviour['action'] == 'server' and printer and document:
             return True
@@ -46,7 +46,7 @@ class Report(models.Model):
         if context is None:
             context = self.pool['res.users'].context_get(cr, uid)
         local_context = dict(context)
-        local_context['must_skip_sent_to_printer'] = True
+        local_context['must_skip_send_to_printer'] = True
         document = self.get_pdf(cr, uid, ids, report_name,
                                 html=html, data=data, context=local_context)
         report = self._get_report_from_name(cr, uid, report_name)

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -30,7 +30,7 @@ class Report(models.Model):
         """ Print a document, do not return the document file """
         if context is None:
             context = self.pool['res.users'].context_get(cr, uid)
-        local_context = dict(context)
+        local_context = context.copy()
         local_context['must_skip_send_to_printer'] = True
         document = self.get_pdf(cr, uid, ids, report_name,
                                 html=html, data=data, context=local_context)

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -65,8 +65,6 @@ class Report(models.Model):
         If the action configured on the report is server, it prints the
         generated document as well.
         """
-        if context is None:
-            context = self.pool['res.users'].context_get(cr, uid)
         document = super(Report, self).get_pdf(cr, uid, ids, report_name,
                                                html=html, data=data,
                                                context=context)
@@ -78,5 +76,4 @@ class Report(models.Model):
                                                 context=context)
         if can_send_report:
             printer.print_document(report, document, report.report_type)
-            context['must_skip_sent_to_printer'] = True
         return document


### PR DESCRIPTION
By calling `super.get_pdf` in print_document we can encounter trouble with MRO resolution
that prevent custom report parser (e.g. override of `get_pdf`) to be called.

The fix consist of not calling `super` and prevent multiple call to 'printer.print_document'
