### PR TITLE
[8.0] [FIX]: change signature of methods print_document & get_pdf for 8.0 api

### DIFF
--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -25,6 +25,7 @@ from openerp import models, exceptions, _, api
 class Report(models.Model):
     _inherit = 'report'
 
+    @api.v7
     def print_document(self, cr, uid, ids, report_name, html=None,
                        data=None, context=None):
         """ Print a document, do not return the document file """
@@ -42,6 +43,12 @@ class Report(models.Model):
                 _('No printer configured to print this report.')
             )
         return printer.print_document(report, document, report.report_type)
+
+    @api.v8
+    def print_document(self, records, report_name, html=None, data=None):
+        return self._model.print_document(self._cr, self._uid,
+                                   records.ids, report_name,
+                                   html=html, data=data, context=self._context)
 
     def _can_print_report(self, cr, uid, ids, behaviour, printer, document,
                           context=None):

--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-from openerp import models, exceptions, _
+from openerp import models, exceptions, _, api
 
 
 class Report(models.Model):
@@ -56,6 +56,7 @@ class Report(models.Model):
             return True
         return False
 
+    @api.v7
     def get_pdf(self, cr, uid, ids, report_name, html=None,
                 data=None, context=None):
         """ Generate a PDF and returns it.
@@ -75,3 +76,9 @@ class Report(models.Model):
         if can_print_report:
             printer.print_document(report, document, report.report_type)
         return document
+
+    @api.v8
+    def get_pdf(self, records, report_name, html=None, data=None):
+        return self._model.get_pdf(self._cr, self._uid,
+                                   records.ids, report_name,
+                                   html=html, data=data, context=self._context)


### PR DESCRIPTION
It is currently not possible to do the following calls:

``` python
report_model = self.env['report']
invoice_model = self.env['account.invoice']

invoices = invoice_model.search([])
report_model.get_pdf(invoices, 'account.report_invoice')
report_model.print_document(invoices, 'account.report_invoice')
```

The signature of the methods print_document & get_pdf have been modified in order to be able to call them from 8.0 api.

I use the same signature as seen in the standard 'report' module:
https://github.com/odoo/odoo/blob/453b373a685d652bc8e542284a0da899ce5ffccd/addons/report/models/report.py#L277
