### PR TITLE
[IMP] base_report_to_printer : new setting

### DIFF
--- a/base_report_to_printer/__openerp__.py
+++ b/base_report_to_printer/__openerp__.py
@@ -46,6 +46,8 @@ Settings can be configured:
 * per user
 * per report
 * per user and report
+* per company and report
+* per user/company and report
 
 
 After installing enable the "Printing / Print Operator" option under access

--- a/base_report_to_printer/printing_view.xml
+++ b/base_report_to_printer/printing_view.xml
@@ -107,7 +107,8 @@
       <field name="arch" type="xml">
         <form string="Report Printing Actions">
           <group col="2">
-              <field name="user_id"/>
+              <field name="company_id" groups="base.group_multi_company" attrs="{'required':[('user_id', '=', False)]}"/>
+              <field name="user_id" attrs="{'required':[('company_id', '=', False)]}"/>
               <field name="action"/>
               <field name="printer_id" select="1"/>
           </group>
@@ -119,6 +120,7 @@
       <field name="model">printing.report.xml.action</field>
       <field name="arch" type="xml">
         <tree string="Report Printing Actions">
+          <field name="company_id" groups="base.group_multi_company"/>
           <field name="user_id"/>
           <field name="action" />
           <field name="printer_id" />

--- a/base_report_to_printer/report_xml_action.py
+++ b/base_report_to_printer/report_xml_action.py
@@ -34,8 +34,9 @@ class report_xml_action(orm.Model):
     _columns = {
         'report_id': fields.many2one('ir.actions.report.xml', 'Report',
                                      required=True, ondelete='cascade'),
-        'user_id': fields.many2one('res.users', 'User', required=True,
-                                   ondelete='cascade'),
+        'user_id': fields.many2one('res.users', 'User', ondelete='cascade'),
+        'company_id': fields.many2one('res.company', 'Company',
+                                      ondelete='cascade'),
         'action': fields.selection(_available_action_types, 'Action',
                                    required=True),
         'printer_id': fields.many2one('printing.printer', 'Printer'),


### PR DESCRIPTION
per company and report

In multi-company environment, it can be usefull to define printer in function of the company instead of the user.
Use case is the following :
2 companies should print the same report on different printer. User can easily change company.
