### PR TITLE
pass context to printer to use it for example in print_options()

### DIFF
--- a/base_report_to_printer/report.py
+++ b/base_report_to_printer/report.py
@@ -42,7 +42,8 @@ class Report(models.Model):
             raise exceptions.Warning(
                 _('No printer configured to print this report.')
             )
-        return printer.print_document(report, document, report.report_type)
+        return printer.with_context(context).print_document(
+            report, document, report.report_type)
 
     @api.v8
     def print_document(self, records, report_name, html=None, data=None):


### PR DESCRIPTION
- context was lost while getting report
- now it will be passed using with_context
- could be used for print_options (example: pass copies amount for
  productlabals)
