### PR TITLE
[FIX][base_report_to_printer] active_ids without active_model

### DIFF
--- a/base_report_to_printer/static/src/js/qwebactionmanager.js
+++ b/base_report_to_printer/static/src/js/qwebactionmanager.js
@@ -14,6 +14,10 @@ openerp.base_report_to_printer = function(instance) {
                     .then(function(print_action){
                         if (print_action && print_action['action'] === 'server') {
                             instance.web.unblockUI();
+                            // active_ids should never exist alone without active_model
+                            if ('active_ids' in action.context && !('active_model' in action.context)) {
+                              action.context['active_model'] = 'pos.order';
+                            }
                             new instance.web.Model('report')
                                 .call('print_document',
                                       [action.context.active_ids,


### PR DESCRIPTION
For some reason active_model is not set on pos.order. This sometimes results
inn exception because reports in some situations tries to browse active_ids
of unknown model. It actually should be fixed in core Odoo, however this fix
is quicker, easier to achieve.

Without this fix calling reporting printing from within POS front-end results in error.

Cheers
Andrius
