### PR TITLE
[9.0] Update travis to new spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,42 @@
+language: python
 sudo: false
-cache: pip
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+python:
+  - "2.7"
 
 addons:
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
-      - python-lxml # because pip installation is slow
+      - python-lxml  # because pip installation is slow
+      - python-simplejson
+      - python-serial
+      - python-yaml
       - cups
       - libcups2-dev
 
-language: python
-python:
-  - "2.7"
-
 env:
-  - VERSION="9.0" LINT_CHECK="1"
-  - VERSION="9.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1" LINT_CHECK="0"
-  - VERSION="9.0" ODOO_REPO="OCA/OCB" UNIT_TEST="1" LINT_CHECK="0"
+  global:
+  - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+  - TRANSIFEX_USER='transbot@odoo-community.org'
+  - secure: HwYn7vV4wIM4ocObmgkylZmaw6FQynkbMiJmoTTfgL3y3Gy6IAPVXgTNXFUiIuYXZZ4B2GOAfcECQejCCw2KP7OCcBo1oGNuSJ2aVwiQcRH1ENDLTsMq1jcB/4vQuAmTS8WEE5nRkPyutwgE4kBYvZC4tENatakafPRAS+iNqpQ=
+
+  matrix:
+  - LINT_CHECK="1"
+  - TRANSIFEX="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 
 virtualenv:
   system_site_packages: true
 
 install:
-  - git clone https://github.com/OCA/maintainer-quality-tools.git $HOME/maintainer-quality-tools
-  - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - pip install pycups==1.9.66
   - pip install PyPDF2==1.18
@@ -34,4 +47,4 @@ script:
   - travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success


### PR DESCRIPTION
This PR updates Travis to new spec. For the most part I just needed `TESTS="1"` for compat w/ Travis2Docker, but why not upgrade the whole thing?
