### PR TITLE
[9.0][IMP] Improove base_report_to_printer security usabilty

### DIFF
--- a/base_report_to_printer/__openerp__.py
+++ b/base_report_to_printer/__openerp__.py
@@ -8,7 +8,7 @@
 
 {
     'name': "Report to printer",
-    'version': '9.0.2.0.0',
+    'version': '9.0.2.1.0',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
               " LasLabs, Odoo Community Association (OCA)",

--- a/base_report_to_printer/migrations/9.0.2.1.0/pre-migration.py
+++ b/base_report_to_printer/migrations/9.0.2.1.0/pre-migration.py
@@ -1,24 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenUpgrade module for Odoo
-#    @copyright 2015-Today: Odoo Community Association
-#    @author: Stephane LE CORNEC
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2016 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
 

--- a/base_report_to_printer/migrations/9.0.2.1.0/pre-migration.py
+++ b/base_report_to_printer/migrations/9.0.2.1.0/pre-migration.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenUpgrade module for Odoo
+#    @copyright 2015-Today: Odoo Community Association
+#    @author: Stephane LE CORNEC
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    # fix that afip should be no updatable
+    openupgrade.logged_query(cr, """
+        UPDATE ir_model_data set noupdate=False
+        WHERE
+            module = 'base_report_to_printer' AND
+            model in ('ir.model.access', 'res.groups')
+        """)

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" ?>
 <odoo>
-  <data noupdate="1">
-    <record id="printing_group_manager" model="res.groups">
-      <field name="name">Printing / Print Manager</field>
-      <field name="users" eval="[(4, ref('base.user_root'))]"/>
+  <data noupdate="0">
+    <record model="ir.module.category" id="module_category_printing">
+      <field name="name">Printing</field>
+      <field name="sequence">90</field>
     </record>
     <record id="printing_group_user" model="res.groups">
-      <field name="name">Printing / Print User</field>
+      <field name="name">User</field>
+      <field name="category_id" ref="module_category_printing"/>
+    </record>
+    <record id="printing_group_manager" model="res.groups">
+      <field name="name">Manager</field>
+      <field name="users" eval="[(4, ref('base.user_root'))]"/>
+      <field name="implied_ids" eval="[(4, ref('printing_group_user'))]"/>
+      <field name="category_id" ref="module_category_printing"/>
     </record>
     <record id="printing_server_group_manager" model="ir.model.access">
       <field name="name">Printing Server Manager</field>
@@ -44,9 +51,6 @@
       <field eval="1" name="perm_write"/>
       <field eval="1" name="perm_create"/>
     </record>
-
-  </data>
-  <data>
     <record id="printing_server_group_user" model="ir.model.access">
       <field name="name">Printing Server User</field>
       <field name="model_id" ref="model_printing_server"/>


### PR DESCRIPTION
1. Add category for grupos Printing for "Print User" and "Print Manager" so that it is rendered like a selection on groups set up (check images)
2. Make res.groups and ir.model.access loaded by this module "updatable" as it is on odoo standards

Before:
![seleccion_020](https://cloud.githubusercontent.com/assets/3016656/21525040/3986e6d2-ccf9-11e6-8e4a-9a1013a75afc.png)


After:
![seleccion_019](https://cloud.githubusercontent.com/assets/3016656/21525021/16bd8fca-ccf9-11e6-8801-15b7b670bd63.png)
