### PR TITLE
[9.0][MIG] Improove migration from v8 of base_report_to_printer

### DIFF
--- a/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
+++ b/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenUpgrade module for Odoo
-#    @copyright 2014-Today: Odoo Community Association
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2016 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
 

--- a/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
+++ b/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenUpgrade module for Odoo
+#    @copyright 2014-Today: Odoo Community Association
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openupgradelib import openupgrade
+
+xmlid_renames = [
+    (
+        'base_report_to_printer.res_groups_printingprintoperator0',
+        'base_report_to_printer.printing_server_group_manager',
+    ),
+    (
+        'base_report_to_printer.ir_model_access_printingprintergroup1',
+        'base_report_to_printer.printing_printer_group_manager',
+    ),
+    (
+        'base_report_to_printer.ir_model_access_printing_action',
+        'base_report_to_printer.printing_action_group_manager',
+    ),
+    (
+        'base_report_to_printer.ir_model_access_printingreportxmlaction',
+        'base_report_to_printer.printing_report_xml_action_group_manager',
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    openupgrade.rename_xmlids(cr, xmlid_renames)


### PR DESCRIPTION
Fix migration from v8. xml id for some none updateble groups and acces rights where renamed as you can see here: [V8](https://github.com/OCA/report-print-send/blob/8.0/base_report_to_printer/security/security.xml) vs [V9](https://github.com/OCA/report-print-send/blob/9.0/base_report_to_printer/security/security.xml)