### PR TITLE
[9.0][FIX] FIX Migration script

### DIFF
--- a/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
+++ b/base_report_to_printer/migrations/9.0.1.0.0/pre-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 xmlid_renames = [
     (
         'base_report_to_printer.res_groups_printingprintoperator0',
-        'base_report_to_printer.printing_server_group_manager',
+        'base_report_to_printer.printing_group_manager',
     ),
     (
         'base_report_to_printer.ir_model_access_printingprintergroup1',


### PR DESCRIPTION
Fix https://github.com/OCA/report-print-send/pull/71
Sorry @pedrobaeza @moylop260 @gonzaloruzafa. I set one wrong id repacement for group manager (is [thisone](https://github.com/OCA/report-print-send/blob/9.0/base_report_to_printer/security/security.xml#L4) and not [thisone](https://github.com/OCA/report-print-send/blob/9.0/base_report_to_printer/security/security.xml#L11). Can you check this fix please?