### PR TITLE
[FIX] base_report_to_printer: Fix Update Job Cron

### DIFF
--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -102,7 +102,7 @@ class PrintingServer(models.Model):
 
         return res
 
-    @api.multi
+    @api.model
     def action_update_jobs(self):
         if not self:
             self = self.search([])


### PR DESCRIPTION
* Fix API issue with Update Job Cron

Before fix:
```
2016-12-28 18:19:24,387 4393 DEBUG odoo openerp.addons.base.ir.ir_cron: cron.object.execute(u'odoo', 1, '*', u'printing.server', u'action_update_jobs')
2016-12-28 18:19:24,388 4393 ERROR odoo openerp.addons.base.ir.ir_cron: Call of self.pool.get('printing.server').action_update_jobs(cr, uid, *()) failed in Job 14
Traceback (most recent call last):
  File "/var/www/odoo/openerp/addons/base/ir/ir_cron.py", line 129, in _callback
    getattr(model, method_name)(cr, uid, *args)
  File "/var/www/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
TypeError: old_api() takes at least 4 arguments (3 given)
```

After fix:
```
2016-12-28 18:25:13,191 4459 DEBUG odoo openerp.addons.base.ir.ir_cron: cron.object.execute(u'odoo', 1, '*', u'printing.server', u'action_update_jobs')
2016-12-28 18:25:13,193 4459 DEBUG odoo openerp.addons.base.ir.ir_cron: 0.001s (printing.server, action_update_jobs)
```

cc @lasley