### PR TITLE
[FIX] Fix the new API migration of base_report_to_printer

### DIFF
--- a/base_report_to_printer/models/report.py
+++ b/base_report_to_printer/models/report.py
@@ -8,28 +8,19 @@ from openerp import models, exceptions, _, api
 class Report(models.Model):
     _inherit = 'report'
 
-    @api.multi
-    def print_document(self, report_name, html=None, data=None):
+    @api.model
+    def print_document(self, record_ids, report_name, html=None, data=None):
         """ Print a document, do not return the document file """
-        res = []
-        context = self.env.context
-        if context is None:
-            context = self.env['res.users'].context_get()
-        local_context = context.copy()
-        local_context['must_skip_send_to_printer'] = True
-        for rec_id in self.with_context(local_context):
-            document = rec_id.get_pdf(report_name, html=html, data=data)
-            report = self._get_report_from_name(report_name)
-            behaviour = report.behaviour()[report.id]
-            printer = behaviour['printer']
-            if not printer:
-                raise exceptions.Warning(
-                    _('No printer configured to print this report.')
-                )
-            res.append(
-                printer.print_document(report, document, report.report_type)
+        document = self.with_context(must_skip_send_to_printer=True).get_pdf(
+            record_ids, report_name, html=html, data=data)
+        report = self._get_report_from_name(report_name)
+        behaviour = report.behaviour()[report.id]
+        printer = behaviour['printer']
+        if not printer:
+            raise exceptions.Warning(
+                _('No printer configured to print this report.')
             )
-        return all(res)
+        return printer.print_document(report, document, report.report_type)
 
     @api.multi
     def _can_print_report(self, behaviour, printer, document):
@@ -66,7 +57,7 @@ class Report(models.Model):
         return document
 
     @api.v8
-    def get_pdf(self, records, report_name, html=None, data=None):
+    def get_pdf(self, docids, report_name, html=None, data=None):
         return self._model.get_pdf(self._cr, self._uid,
-                                   records.ids, report_name,
+                                   docids, report_name,
                                    html=html, data=data, context=self._context)

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -2,7 +2,9 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import mock
 from openerp.tests.common import TransactionCase
+from openerp import exceptions
 
 
 class StopTest(Exception):
@@ -14,10 +16,24 @@ class TestReport(TransactionCase):
     def setUp(self):
         super(TestReport, self).setUp()
         self.Model = self.env['report']
+        self.server = self.env['printing.server'].create({})
         self.report_vals = {}
 
     def new_record(self):
         return self.Model.create(self.report_vals)
+
+    def new_printer(self):
+        return self.env['printing.printer'].create({
+            'name': 'Printer',
+            'server_id': self.server.id,
+            'system_name': 'Sys Name',
+            'default': True,
+            'status': 'unknown',
+            'status_message': 'Msg',
+            'model': 'res.users',
+            'location': 'Location',
+            'uri': 'URI',
+        })
 
     def test_can_print_report_context_skip(self):
         """ It should return False based on context """
@@ -42,3 +58,42 @@ class TestReport(TransactionCase):
             {'action': 'server'}, True, False
         )
         self.assertFalse(res)
+
+    def test_print_document_not_printable(self):
+        """ It should print the report, regardless of the defined behaviour """
+        report = self.env['ir.actions.report.xml'].search([
+            ('report_type', '=', 'qweb-pdf'),
+        ], limit=1)
+        report.printing_printer_id = self.new_printer()
+        records = self.env[report.model].search([], limit=5)
+
+        with mock.patch('openerp.addons.base_report_to_printer.models.'
+                        'printing_printer.PrintingPrinter.'
+                        'print_document') as print_document:
+            self.env['report'].print_document(records.ids, report.report_name)
+            print_document.assert_called_once()
+
+    def test_print_document_printable(self):
+        """ It should print the report, regardless of the defined behaviour """
+        report = self.env['ir.actions.report.xml'].search([
+            ('report_type', '=', 'qweb-pdf'),
+        ], limit=1)
+        report.property_printing_action_id.action_type = 'server'
+        report.printing_printer_id = self.new_printer()
+        records = self.env[report.model].search([], limit=5)
+
+        with mock.patch('openerp.addons.base_report_to_printer.models.'
+                        'printing_printer.PrintingPrinter.'
+                        'print_document') as print_document:
+            self.env['report'].print_document(records.ids, report.report_name)
+            print_document.assert_called_once()
+
+    def test_print_document_no_printer(self):
+        """ It should raise an error """
+        report = self.env['ir.actions.report.xml'].search([
+            ('report_type', '=', 'qweb-pdf'),
+        ], limit=1)
+        records = self.env[report.model].search([], limit=5)
+
+        with self.assertRaises(exceptions.UserError):
+            self.env['report'].print_document(records.ids, report.report_name)


### PR DESCRIPTION
The new API migration was made to `@api.multi` because of the `cr, uid, ids` signature, but `ids` was the ids of the records to print here, not the report's ids. This method should be `@api.model`.
Also, the new API version of `get_pdf` get directly the ids of the records to print in the standard module, not a recordset.

Fixes https://github.com/OCA/report-print-send/issues/63 and https://github.com/OCA/report-print-send/issues/75
Supersedes https://github.com/OCA/report-print-send/pull/67