### PR TITLE
[ADD] Add the base_report_to_printer_mail module

### DIFF
--- a/base_report_to_printer_mail/README.rst
+++ b/base_report_to_printer_mail/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Report to printer - Mail
+========================
+
+This module fixes the compatibility between the Report to printer and Mail modules.
+
+When generating an email, the report was also printed on the printer.
+With this module, the report is not sent to the printer in this case.
+
+Installation
+============
+
+This module will automatically install itself when both Report to printer and Mail module are installed.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/report-print-send/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Sylvain Garancher <sylvain.garancher@syleam.fr>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_report_to_printer_mail/__init__.py
+++ b/base_report_to_printer_mail/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/base_report_to_printer_mail/__openerp__.py
+++ b/base_report_to_printer_mail/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Report to printer - Mail',
+    'version': '9.0.1.0.0',
+    'category': 'Generic Modules/Base',
+    'summary': 'Avoid printing a report on email send',
+    'author': 'SYLEAM, Odoo Community Association (OCA)',
+    'website': 'http://www.Syleam.fr/',
+    'license': 'AGPL-3',
+    'depends': [
+        'base_report_to_printer',
+        'mail'
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/base_report_to_printer_mail/models/__init__.py
+++ b/base_report_to_printer_mail/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import mail_template

--- a/base_report_to_printer_mail/models/mail_template.py
+++ b/base_report_to_printer_mail/models/mail_template.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 SYLEAM Info Services
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models
+
+
+class MailTemplate(models.Model):
+    _inherit = 'mail.template'
+
+    @api.multi
+    def generate_email(self, res_ids, fields=None):
+        return super(MailTemplate, self.with_context(
+            must_skip_send_to_printer=True
+        )).generate_email(res_ids, fields=fields)

--- a/base_report_to_printer_mail/tests/__init__.py
+++ b/base_report_to_printer_mail/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_report

--- a/base_report_to_printer_mail/tests/test_report.py
+++ b/base_report_to_printer_mail/tests/test_report.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+from openerp.tests.common import TransactionCase
+
+
+class StopTest(Exception):
+    pass
+
+
+class TestReport(TransactionCase):
+
+    def setUp(self):
+        super(TestReport, self).setUp()
+        self.Model = self.env['report']
+        self.server = self.env['printing.server'].create({})
+        self.report_vals = {}
+
+    def new_printer(self):
+        return self.env['printing.printer'].create({
+            'name': 'Printer',
+            'server_id': self.server.id,
+            'system_name': 'Sys Name',
+            'default': True,
+            'status': 'unknown',
+            'status_message': 'Msg',
+            'model': 'res.users',
+            'location': 'Location',
+            'uri': 'URI',
+        })
+
+    def test_generate_email(self):
+        """ Check that generating an email doesn't print the report """
+        report = self.env['ir.actions.report.xml'].search([
+            ('report_type', '=', 'qweb-pdf'),
+        ], limit=1)
+        report.property_printing_action_id.type = 'server'
+        report.printing_printer_id = self.new_printer()
+        records = self.env[report.model].search([], limit=5)
+
+        model = self.env['ir.model'].search([('model', '=', report.model)])
+        mail_template = self.env['mail.template'].create({
+            'model_id': model.id,
+            'report_template': report.id,
+        })
+
+        with mock.patch('openerp.addons.base_report_to_printer.models.'
+                        'printing_printer.PrintingPrinter.'
+                        'print_document') as print_document:
+            print_document.side_effect = Exception
+
+            # Check that the report is printed when called directly
+            with self.assertRaises(Exception):
+                self.env['report'].get_pdf(records.ids, report.report_name)
+
+            # Check that the same report is not printed when called for email
+            mail_template.generate_email(records.ids)


### PR DESCRIPTION
An auto-install module for compatibility between base_report_to_printer and mail by avoiding to print reports when generating them for email attachments.

Fixes https://github.com/OCA/report-print-send/issues/56