### PR TITLE
[9.0][FIX] Move dependencies from Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,6 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  - pip install pycups==1.9.66
-  - pip install PyPDF2==1.18
-  - pip install requests
-  - pip install zpl2
-  - git clone https://github.com/OCA/reporting-engine -b ${VERSION} $HOME/reporting-engine
 
 script:
   - travis_run_tests

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+reporting-engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pycups==1.9.66
+PyPDF2==1.18
+requests
+zpl2


### PR DESCRIPTION
This moves the depends to a requirements and oca_depends file, instead of Travis.
