### PR TITLE
[10] FIX format parameter

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -95,10 +95,10 @@ class PrintingPrinter(models.Model):
         finally:
             os.close(fd)
 
-        return self.print_file(file_name, report=report, copies=copies)
+        return self.print_file(file_name, report=report, copies=copies, format=format)
 
     @api.multi
-    def print_file(self, file_name, report=None, copies=1):
+    def print_file(self, file_name, report=None, copies=1, format=None):
         """ Print a file """
         self.ensure_one()
 

--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -95,7 +95,8 @@ class PrintingPrinter(models.Model):
         finally:
             os.close(fd)
 
-        return self.print_file(file_name, report=report, copies=copies, format=format)
+        return self.print_file(
+            file_name, report=report, copies=copies, format=format)
 
     @api.multi
     def print_file(self, file_name, report=None, copies=1, format=None):


### PR DESCRIPTION
To be able to print files in raw format it's needed to set this parameter.

Previous code was not able to print raw files, but it didn't get error because 'format' used on line 107 is assumed as a format funtion, because format parameter was not on this scope.