### PR TITLE
[9.0] Backport the format parameter fix

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -117,10 +117,11 @@ class PrintingPrinter(models.Model):
         finally:
             os.close(fd)
 
-        return self.print_file(file_name, report=report, copies=copies)
+        return self.print_file(
+            file_name, report=report, copies=copies, format=format)
 
     @api.multi
-    def print_file(self, file_name, report=None, copies=1):
+    def print_file(self, file_name, report=None, copies=1, format=None):
         """ Print a file """
         self.ensure_one()
 


### PR DESCRIPTION
Just cherry-picked the fix from @angelmoya on 10.0