### PR TITLE
allow to avoid 'Recall last saved values' command

### DIFF
--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -39,6 +39,10 @@ class PrintingLabelZpl2(models.Model):
         comodel_name='printing.label.zpl2.component', inverse_name='label_id',
         string='Label Components',
         help='Components which will be printed on the label.')
+    restore_saved_config = fields.Boolean(
+        string="Restore printer's configuration",
+        help="Restore printer's saved configuration and end of each label ",
+        default=True)
 
     @api.multi
     def _generate_zpl2_components_data(
@@ -167,7 +171,8 @@ class PrintingLabelZpl2(models.Model):
                 page_count=page_count)
 
             # Restore printer's configuration and end the label
-            label_data.configuration_update(zpl2.CONF_RECALL_LAST_SAVED)
+            if self.restore_saved_config:
+                label_data.configuration_update(zpl2.CONF_RECALL_LAST_SAVED)
             label_data.label_end()
 
         return label_data.output()

--- a/printer_zpl2/views/printing_label_zpl2.xml
+++ b/printer_zpl2/views/printing_label_zpl2.xml
@@ -26,6 +26,7 @@
                     <field name="width"/>
                     <field name="origin_x"/>
                     <field name="origin_y"/>
+                    <field name="restore_saved_config"/>
                 </group>
                 <field name="component_ids" nolabel="1" colspan="4">
                     <tree string="Label Component">


### PR DESCRIPTION
This command causes Godex printers in GZPL emulation not to
print the label, this might be a firmware bug
(tested on Godex G500 Z1.00E )

The default behaviour is unchanged.