### PR TITLE
[FIX] base_report_to_printer: A button method should be @api.multi

### DIFF
--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -102,7 +102,6 @@ class PrintingServer(models.Model):
 
         return res
 
-    @api.model
     def action_update_jobs(self):
         if not self:
             self = self.search([])


### PR DESCRIPTION
Steps to reproduce the bug: Click on the "Update Jobs" button on a printing server.