### PR TITLE
[FIX] Minor bugfixes

### DIFF
--- a/base_report_to_printer/views/ir_actions_report_xml_view.xml
+++ b/base_report_to_printer/views/ir_actions_report_xml_view.xml
@@ -6,8 +6,8 @@
     <field name="model">ir.actions.report.xml</field>
     <field name="inherit_id" ref="base.act_report_xml_view" />
     <field name="arch" type="xml">
-      <xpath expr="//page[@name='security']">
-        <page string="Print">
+      <xpath expr="//page[@name='security']" position="before" >
+        <page string="Print" name="print" >
           <group>
             <field name="property_printing_action_id"/>
             <field name="printing_printer_id"/>

--- a/printer_tray/__manifest__.py
+++ b/printer_tray/__manifest__.py
@@ -24,5 +24,5 @@
         'python': ['cups'],
     },
     'installable': True,
-    'application': True,
+    'application': False,
 }


### PR DESCRIPTION
Printer Tray isn't an app
Base Report To printer ir.actions.report.xml view xpath error and missing page name
Put to before security as security tab doesn't do much and if this module is installed it should be the hero page