### PR TITLE
[PROOF OF CONCEPT] Auto print DESIGN FEEDBACK ONLY - No Merge

### DIFF
--- a/base_auto_print/__init__.py
+++ b/base_auto_print/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_auto_print/__manifest__.py
+++ b/base_auto_print/__manifest__.py
@@ -1,0 +1,14 @@
+# noinspection PyStatementEffect
+{
+    'name': 'Automatic Print Rules',
+    'version': '10.0.1.0.0',
+    'author': 'O4SB',
+    'website': 'http://www.openforsmallbusiness.co.nz',
+    'depends': ['base_report_to_printer', 'queue_job', 'stock', 'mrp', 'sale'],
+    "summary": 'This module allows to select printer based on properties of '
+               'record being printed',
+    'data': [
+             'views/ir_actions_report_xml.xml',
+             'security/ir.model.access.csv'],
+
+}

--- a/base_auto_print/models/__init__.py
+++ b/base_auto_print/models/__init__.py
@@ -1,0 +1,1 @@
+from . import auto_print_rule

--- a/base_auto_print/models/auto_print_rule.py
+++ b/base_auto_print/models/auto_print_rule.py
@@ -1,0 +1,71 @@
+from odoo import models, fields, api
+from odoo.addons.queue_job.job import job
+
+
+class Report(models.Model):
+    _inherit = 'report'
+
+    @job
+    @api.model
+    def _print_document_automatically(self, report_name, records, filters):
+        Report = self.env['report']
+        report = Report._get_report_from_name(report_name)
+        PrintRule = self.env['auto.print.rule'].sudo()
+        for record in records:
+            search_args = [('action_id', '=', report.id)]
+            for field in filters:
+                if field in record._fields:
+                    search_args.append(
+                        getattr(PrintRule, '_handle_field_%s' % field,
+                                PrintRule._field_handle_default)(record, field))
+            rule = PrintRule.search(search_args)
+            # or should we fail here, what if user has no rule
+            sudo_uid = rule[0].user_id.id if rule else self.env.uid
+            Report.sudo(sudo_uid).print_document([record.id], report_name)
+        return True
+
+    @api.model
+    def print_document_automatically(self, report_name, records, filters,
+                                     delay=True):
+        if delay:
+            self.with_delay()._print_document_automatically(
+                report_name, records, filters)
+        else:
+            self._print_document_automatically(report_name, records, filters)
+
+
+class IrActionsReportXml(models.Model):
+
+    _inherit = 'ir.actions.report.xml'
+
+    auto_print_rule_ids = fields.One2many(
+        comodel_name='auto.print.rule',
+        inverse_name='action_id',
+        string='Automated Print Rules',
+    )
+
+
+class AutomatedPrintCriteria(models.Model):
+    _name = 'auto.print.rule'
+
+    action_id = fields.Many2one(
+        comodel_name='ir.actions.report.xml', required=True)
+    user_id = fields.Many2one(comodel_name='res.users', string='Print as User')
+    product = fields.Many2many(
+        comodel_name='product.product', string='Products')
+    company = fields.Many2many(comodel_name='res.company', string='Companies')
+    warehouse = fields.Many2many(
+        comodel_name='stock.warehouse', string='Warehouses')
+    product_category = fields.Many2many(
+        comodel_name='product.category', string='Product Categories')
+
+    @api.model
+    def _field_handle_default(self, record, field):
+        self.ensure_one()
+        return field, 'in', record[field].ids()
+
+    @api.model
+    def _field_handle_product_category(self, record, field):
+        self.ensure_one()
+        return ('product_id.product_categ_id', 'in',
+                record.product_id.product_categ_id.ids())

--- a/base_auto_print/security/ir.model.access.csv
+++ b/base_auto_print/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auto_print,Read Auto Print Rules,model_auto_print_rule,base.group_user,1,0,0,0
+manage_auto_print,Manage Auto Print,model_auto_print_rule,base_report_to_printer.printing_group_manager,1,1,1,1

--- a/base_auto_print/views/auto_print_rule.xml
+++ b/base_auto_print/views/auto_print_rule.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<odoo>
+
+  <record model="ir.ui.view" id="auto_form">
+    <field name="name">printing.report.xml.action.form</field>
+    <field name="model">printing.report.xml.action</field>
+    <field name="arch" type="xml">
+      <form string="Report Printing Actions">
+        <group col="2">
+            <field name="user_id"/>
+            <field name="action"/>
+            <field name="printer_id" select="1"/>
+        </group>
+      </form>
+    </field>
+  </record>
+  <record model="ir.ui.view" id="auto_print_rule_view_tree">
+    <field name="name">auto.print.rule.tree (in automatic_printing)</field>
+    <field name="model">printing.report.xml.action</field>
+    <field name="arch" type="xml">
+      <tree string="Report Printing Actions">
+        <field name="user_id"/>
+        <field name="action" />
+        <field name="printer_id" />
+      </tree>
+    </field>
+  </record>
+
+  <!-- Add a shorcut to "Actions/Report" in the Printing menu -->
+  <menuitem id="printing_report_xml_action_menu"
+    sequence="30"
+    parent="printing_menu"
+    action="base.ir_action_report_xml"/>
+
+</odoo>

--- a/base_auto_print/views/ir_actions_report_xml.xml
+++ b/base_auto_print/views/ir_actions_report_xml.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record model="ir.ui.view" id="act_report_xml_view">
+        <field name="name">ir.actions.report.xml.form (in automatic printing)</field>
+        <field name="model">ir.actions.report.xml</field>
+        <field name="inherit_id" ref="base_report_to_printer.act_report_xml_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='printing_action_ids']" position="after">
+                <separator string="Specific users for Automated Documents"/>
+                <field name="auto_print_rule_ids" mode="tree">
+                    <tree string="Automatic Printing Rules" editable="bottom">
+                        <field name="user_id" context="{'active_test': False}"/>
+                        <field name="company" widget="many2many_tags" />
+                        <field name="warehouse" widget="many2many_tags" />
+                    </tree>
+                </field>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/base_report_to_printer/views/ir_actions_report_xml_view.xml
+++ b/base_report_to_printer/views/ir_actions_report_xml_view.xml
@@ -6,8 +6,8 @@
     <field name="model">ir.actions.report.xml</field>
     <field name="inherit_id" ref="base.act_report_xml_view" />
     <field name="arch" type="xml">
-      <xpath expr="//page[@name='security']">
-        <page string="Print">
+      <xpath expr="//page[@name='security']" position="before" >
+        <page string="Print" name="print" >
           <group>
             <field name="property_printing_action_id"/>
             <field name="printing_printer_id"/>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,17 @@
+# List the OCA project dependencies, one per line
+# Add a repository url and branch if you need a forked version
+#
+# Examples
+# ========
+#
+# To depend on the standard version of sale-workflow, use:
+# sale-workflow
+#
+# To explicitely give the URL of a fork, and still use the version specified in
+# .travis.yml, use:
+# sale-workflow https://github.com/OCA/sale-workflow
+#
+# To provide both the URL and a branch, use:
+# sale-workflow https://github.com/OCA/sale-workflow branchname
+
+queue

--- a/printer_tray/__manifest__.py
+++ b/printer_tray/__manifest__.py
@@ -24,5 +24,5 @@
         'python': ['cups'],
     },
     'installable': True,
-    'application': True,
+    'application': False,
 }


### PR DESCRIPTION
Hi,

NOTE: This is far from finished or finalized - is for design feedback.  

## Background
In 2010, long before OCA/queue and base_report_to_printer I wrote a module to automatically trigger printing on changes in workflow based on some attributes of a report.  Was pretty basic stuff, used subprocess to manually call lp, relied on CUPS instances for tray selection, a view to handle errors and reprints and a cron to manage queues to speed user response time.  But it worked well, and at v6 and 7 base_report_to_printer didn't really do what it needed to do so I just kept porting.  However, today doing a v10 migration I decided to revisit and just hacked away a few hours to see if it could be done.

## Use case
Base report to printer is user-centric, however when automatically printing documents as part of a 'workflow' it is often a documents properties that matter.  e.g. There is no point printing New Yorks pickings in the LA warehouse even if a dodgers fan loaded the order. 

## Design
So how to mix what I did with base_report_to_printer.
Cool things to know - inactive users can still be used in sudo.

In working, this is how it currently works.  Rather than explain I'll just use screenshots, its clearer.
1. Add automatic user (eventually inactive, but I need to inherit a base_report view first), conditions for use, and print behaviour to a report
![image](https://user-images.githubusercontent.com/5093264/29120320-cb3e079e-7d5d-11e7-9379-3f4cde36b9f9.png)
2. Add a server action
![image](https://user-images.githubusercontent.com/5093264/29120408-1e1cf920-7d5e-11e7-966d-ebd36794ed36.png)
3. Add an automated action
![image](https://user-images.githubusercontent.com/5093264/29120453-4fce8614-7d5e-11e7-9db2-89d9ace05e26.png)

By default - jobs are set to delay as the view is that the user is usually not interested in an immediate print and indeed may be half a world away from the print destination.

Design Issues:

- First, is this something OCA is interested in, or is it just my unique case?
- I think eventually there will be for example sale_auto_print, mrp_auto_print etc - its just all bundled in there atm for getting POC together.
- Currently it relies mostly on many2many field names for filtering, I'd like for these to be specified dynamically but I am not sure how.  At the very least irrelevant fields should be hidden (again not sure how).  
- I'll probably make company_id a many2one field.
- The fields to filter on are specified in the function call - I did this because at the model level it made no sense (different reports may filter on different fields, or the same report in say different state.  transitions) and I couldn't think of a sane unconfusing way to do that at report level.  Also for this reason I departed from usual field names.
- The setup seems clumsy, is there a better way to achieve?
- One of the issues that led to this approach was base_report_to_printer having no knowledge of the records it is being asked to print, I'm OK with the user-centric part and sudo, but if enhancing base_report_to_printer so it has knowledge of the records coming its way is deemed better, I'm OK with that as well.

There is lots more but I kind of feel this is real long already.

Really anything else.

