### PR TITLE
base_report_to_printer: Remove temp file after printing

### DIFF
--- a/base_report_to_printer/printing.py
+++ b/base_report_to_printer/printing.py
@@ -161,6 +161,7 @@ class PrintingPrinter(models.Model):
                              file_name,
                              options=options)
         _logger.info("Printing job: '%s' on %s" % (file_name, CUPS_HOST))
+        os.remove(file_name)
         return True
 
     @api.multi


### PR DESCRIPTION
The created temp file should be removed once the print job is created.