### PR TITLE
[9.0] Added graphic image support on ZPL labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,16 @@ addons:
       - cups
       - libcups2-dev
 
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+
 env:
   global:
   - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - WKHTMLTOPDF_VERSION="0.12.4"
   - TRANSIFEX_USER='transbot@odoo-community.org'
+  - WKHTMLTOPDF_VERSION='0.12.4'
   - secure: HwYn7vV4wIM4ocObmgkylZmaw6FQynkbMiJmoTTfgL3y3Gy6IAPVXgTNXFUiIuYXZZ4B2GOAfcECQejCCw2KP7OCcBo1oGNuSJ2aVwiQcRH1ENDLTsMq1jcB/4vQuAmTS8WEE5nRkPyutwgE4kBYvZC4tENatakafPRAS+iNqpQ=
 
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - WKHTMLTOPDF_VERSION="0.12.4"
   - TRANSIFEX_USER='transbot@odoo-community.org'
-  - WKHTMLTOPDF_VERSION='0.12.4'
   - secure: HwYn7vV4wIM4ocObmgkylZmaw6FQynkbMiJmoTTfgL3y3Gy6IAPVXgTNXFUiIuYXZZ4B2GOAfcECQejCCw2KP7OCcBo1oGNuSJ2aVwiQcRH1ENDLTsMq1jcB/4vQuAmTS8WEE5nRkPyutwgE4kBYvZC4tENatakafPRAS+iNqpQ=
 
   matrix:

--- a/printer_zpl2/README.rst
+++ b/printer_zpl2/README.rst
@@ -82,6 +82,7 @@ Contributors
 ------------
 
 * Sylvain Garancher <sylvain.garancher@syleam.fr>
+* Jos De Graeve <Jos.DeGraeve@apertoso.be>
 
 Maintainer
 ----------

--- a/printer_zpl2/__openerp__.py
+++ b/printer_zpl2/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Printer ZPL II',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Printer',
     'author': 'SYLEAM, Odoo Community Association (OCA)',
     'website': 'http://www.syleam.fr/',

--- a/printer_zpl2/__openerp__.py
+++ b/printer_zpl2/__openerp__.py
@@ -6,7 +6,7 @@
     'name': 'Printer ZPL II',
     'version': '9.0.1.0.1',
     'category': 'Printer',
-    'author': 'SYLEAM, Odoo Community Association (OCA)',
+    'author': 'SYLEAM, Apertoso NV, Odoo Community Association (OCA)',
     'website': 'http://www.syleam.fr/',
     'license': 'AGPL-3',
     'external_dependencies': {

--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -122,6 +122,17 @@ class PrintingLabelZpl2(models.Model):
                         base64.decodestring(
                             component.graphic_image or data
                         )))
+                if component.width and component.height:
+                    pil_image = pil_image.resize(
+                        (component.width, component.height, )
+                    )
+                # rotation ( pil rotates counter clockwise )
+                if component.orientation == zpl2.ORIENTATION_ROTATED:
+                    pil_image = pil_image.rotate(-90)
+                elif component.orientation == zpl2.ORIENTATION_INVERTED:
+                    pil_image = pil_image.rotate(-180)
+                elif component.orientation == zpl2.ORIENTATION_BOTTOM_UP:
+                    pil_image = pil_image.rotate(-270)
                 label_data.graphic_image(
                     component_offset_x, component_offset_y,
                     pil_image

--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-import time
+import base64
 import datetime
+import io
 import logging
+import time
+
+from PIL import Image
 from openerp import api, exceptions, fields, models
-from openerp.tools.translate import _
 from openerp.tools.safe_eval import safe_eval
+from openerp.tools.translate import _
 
 _logger = logging.getLogger(__name__)
 
@@ -113,6 +116,16 @@ class PrintingLabelZpl2(models.Model):
                         zpl2.ARG_COLOR: component.color,
                         zpl2.ARG_ROUNDING: component.rounding,
                     })
+            elif component.component_type == 'graphic':
+                pil_image = Image.open(
+                    io.BytesIO(
+                        base64.decodestring(
+                            component.graphic_image or data
+                        )))
+                label_data.graphic_image(
+                    component_offset_x, component_offset_y,
+                    pil_image
+                )
             elif component.component_type == 'circle':
                 label_data.graphic_circle(
                     component_offset_x, component_offset_y, {

--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -7,7 +7,7 @@ import io
 import logging
 import time
 
-from PIL import Image
+from PIL import Image, ImageOps
 from openerp import api, exceptions, fields, models
 from openerp.tools.safe_eval import safe_eval
 from openerp.tools.translate import _

--- a/printer_zpl2/models/printing_label_zpl2_component.py
+++ b/printer_zpl2/models/printing_label_zpl2_component.py
@@ -144,7 +144,6 @@ class PrintingLabelZpl2Component(models.Model):
         string='Left Margin',
         help='Left margin for the second and other lines in the block.')
     graphic_image = fields.Binary(
-        "Image",
-        attachment=True,
-        help="This field holds a static image to print. "
-             "If not set, the data field is evaluated")
+        string='Image', attachment=True,
+        help='This field holds a static image to print. '
+             'If not set, the data field is evaluated.')

--- a/printer_zpl2/models/printing_label_zpl2_component.py
+++ b/printer_zpl2/models/printing_label_zpl2_component.py
@@ -34,6 +34,7 @@ class PrintingLabelZpl2Component(models.Model):
             ('text', 'Text'),
             ('rectangle', 'Rectangle / Line'),
             ('circle', 'Circle'),
+            ('graphic', 'Graphic'),
             (zpl2.BARCODE_CODE_11, 'Code 11'),
             (zpl2.BARCODE_INTERLEAVED_2_OF_5, 'Interleaved 2 of 5'),
             (zpl2.BARCODE_CODE_39, 'Code 39'),
@@ -142,3 +143,8 @@ class PrintingLabelZpl2Component(models.Model):
     block_left_margin = fields.Integer(
         string='Left Margin',
         help='Left margin for the second and other lines in the block.')
+    graphic_image = fields.Binary(
+        "Image",
+        attachment=True,
+        help="This field holds the image used as image for "
+             "the product, limited to 1024x1024px.")

--- a/printer_zpl2/models/printing_label_zpl2_component.py
+++ b/printer_zpl2/models/printing_label_zpl2_component.py
@@ -146,5 +146,5 @@ class PrintingLabelZpl2Component(models.Model):
     graphic_image = fields.Binary(
         "Image",
         attachment=True,
-        help="This field holds the image used as image for "
-             "the product, limited to 1024x1024px.")
+        help="This field holds a static image to print. "
+             "If not set, the data field is evaluated")

--- a/printer_zpl2/views/printing_label_zpl2.xml
+++ b/printer_zpl2/views/printing_label_zpl2.xml
@@ -58,11 +58,11 @@
                             </group>
                         </group>
                         <notebook colspan="4">
-                            <page string="Format" attrs="{'invisible': [('component_type', 'in', ('sublabel','graphic'))]}">
+                            <page string="Format" attrs="{'invisible': [('component_type', 'in', ('sublabel'))]}">
                                 <group>
                                     <field name="height"/>
-                                    <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'rectangle', 'circle'))]}"/>
-                                    <field name="reverse_print"/>
+                                    <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'graphic', 'rectangle', 'circle'))]}"/>
+                                    <field name="reverse_print" attrs="{'invisible': [('component_type', 'in', ('graphic'))]}"/>
                                     <field name="orientation" attrs="{'invisible': [('component_type', 'in', ('rectangle', 'circle'))]}"/>
                                     <field name="font" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>
                                     <field name="in_block" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>

--- a/printer_zpl2/views/printing_label_zpl2.xml
+++ b/printer_zpl2/views/printing_label_zpl2.xml
@@ -58,11 +58,11 @@
                             </group>
                         </group>
                         <notebook colspan="4">
-                            <page string="Format" attrs="{'invisible': [('component_type', 'in', ('sublabel'))]}">
+                            <page string="Format" attrs="{'invisible': [('component_type', '=', 'sublabel')]}">
                                 <group>
                                     <field name="height"/>
-                                    <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'graphic', 'rectangle', 'circle'))]}"/>
-                                    <field name="reverse_print" attrs="{'invisible': [('component_type', 'in', ('graphic'))]}"/>
+                                    <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'rectangle', 'circle', 'graphic'))]}"/>
+                                    <field name="reverse_print"/>
                                     <field name="orientation" attrs="{'invisible': [('component_type', 'in', ('rectangle', 'circle'))]}"/>
                                     <field name="font" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>
                                     <field name="in_block" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>
@@ -71,7 +71,7 @@
                                 </group>
                             </page>
                             <!-- Barcode specific arguments -->
-                            <page string="Barcode Format" attrs="{'invisible': [('component_type', 'in', ('text', 'rectangle', 'circle', 'sublabel','graphic'))]}">
+                            <page string="Barcode Format" attrs="{'invisible': [('component_type', 'in', ('text', 'rectangle', 'circle', 'sublabel', 'graphic'))]}">
                                 <group>
                                     <field name="check_digits"/>
                                     <field name="interpretation_line"/>

--- a/printer_zpl2/views/printing_label_zpl2.xml
+++ b/printer_zpl2/views/printing_label_zpl2.xml
@@ -53,11 +53,12 @@
                             </group>
                             <group>
                                 <field name="data" attrs="{'invisible': [('component_type', 'in', ('rectangle', 'circle'))]}"/>
+                                <field name="graphic_image" attrs="{'invisible': [('component_type', '!=', 'graphic')]}"/>
                                 <field name="sublabel_id" attrs="{'invisible': [('component_type', '!=', 'sublabel')]}"/>
                             </group>
                         </group>
                         <notebook colspan="4">
-                            <page string="Format" attrs="{'invisible': [('component_type', '=', ('sublabel'))]}">
+                            <page string="Format" attrs="{'invisible': [('component_type', 'in', ('sublabel','graphic'))]}">
                                 <group>
                                     <field name="height"/>
                                     <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'rectangle', 'circle'))]}"/>
@@ -70,7 +71,7 @@
                                 </group>
                             </page>
                             <!-- Barcode specific arguments -->
-                            <page string="Barcode Format" attrs="{'invisible': [('component_type', 'in', ('text', 'rectangle', 'circle', 'sublabel'))]}">
+                            <page string="Barcode Format" attrs="{'invisible': [('component_type', 'in', ('text', 'rectangle', 'circle', 'sublabel','graphic'))]}">
                                 <group>
                                     <field name="check_digits"/>
                                     <field name="interpretation_line"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pycups==1.9.66
 PyPDF2==1.18
 requests
-zpl2
+zpl2>=1.1


### PR DESCRIPTION
This PR adds support for graphic images on ZPL labels.

A new field type is defined which allow to print a static image or an image field.

TODO:
* update documentation

Depends on https://github.com/syleam/python-zpl2/pull/5

