### PR TITLE
[FIX] base_report_to_printer: Stateless tests

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -98,6 +98,7 @@ Contributors
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Dave Lasley <dave@laslabs.com>
 * Sylvain Garancher <sylvain.garancher@syleam.fr>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': "Report to printer",
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
               " LasLabs, Odoo Community Association (OCA)",

--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -8,25 +8,25 @@ odoo.define('base_report_to_printer.print', function(require) {
 
     ActionManager.include({
         ir_actions_report_xml: function(action, options) {
-            action = _.clone(action);
+            var _action = _.clone(action);
             var _t = core._t;
             var self = this;
             var _super = this._super;
 
-            if ('report_type' in action && action.report_type === 'qweb-pdf') {
+            if ('report_type' in _action && _action.report_type === 'qweb-pdf') {
                 framework.blockUI();
                 new Model('ir.actions.report.xml')
-                    .call('print_action_for_report_name', [action.report_name])
+                    .call('print_action_for_report_name', [_action.report_name])
                     .then(function(print_action){
                         if (print_action && print_action.action === 'server') {
                             framework.unblockUI();
                             new Model('report')
                                 .call('print_document',
-                                      [action.context.active_ids,
-                                       action.report_name,
+                                      [_action.context.active_ids,
+                                       _action.report_name,
                                        ],
-                                      {data: action.data || {},
-                                       context: action.context || {},
+                                      {data: _action.data || {},
+                                       context: _action.context || {},
                                        })
                                 .then(function(){
                                     self.do_notify(_t('Report'),
@@ -37,14 +37,12 @@ odoo.define('base_report_to_printer.print', function(require) {
 
                                 });
                         } else {
-                            return _super.apply(self, [action, options]);
+                            return _super.apply(self, [_action, options]);
                         }
                     });
             } else {
-                return _super.apply(self, [action, options]);
+                return _super.apply(self, [_action, options]);
             }
         }
     });
-    
 });
-

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 LasLabs Inc.
+# Copyright 2017 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import mock

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -7,6 +7,7 @@ import mock
 from odoo.tests import common
 from odoo import exceptions
 
+
 @common.at_install(False)
 @common.post_install(True)
 class TestReport(common.HttpCase):

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -3,21 +3,43 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import mock
-from odoo.tests.common import HttpCase
+from odoo.tests import common
 from odoo import exceptions
 
-
-class StopTest(Exception):
-    pass
-
-
-class TestReport(HttpCase):
-
+@common.at_install(False)
+@common.post_install(True)
+class TestReport(common.HttpCase):
     def setUp(self):
         super(TestReport, self).setUp()
         self.Model = self.env['report']
         self.server = self.env['printing.server'].create({})
         self.report_vals = {}
+        self.report_imd = self.env["ir.model.data"].create({
+            "name": "test",
+            "module": "base_report_to_printer",
+            "model": "ir.ui.view",
+        })
+        self.report_view = self.env["ir.ui.view"].create({
+            "name": "Test",
+            "type": "qweb",
+            "xml_id": "base_report_to_printer.test",
+            "model_data_id": self.report_imd.id,
+            "arch": """<t t-name="base_report_to_printer.test">
+                <div>Test</div>
+            </t>""",
+        })
+        self.report_imd.res_id = self.report_view.id
+        self.report = self.env["ir.actions.report.xml"].create({
+            "name": "Test",
+            "report_type": "qweb-pdf",
+            "model": "res.partner",
+            "report_name": "base_report_to_printer.test",
+        })
+        self.partners = self.env["res.partner"]
+        for n in range(5):
+            self.partners += self.env["res.partner"].create({
+                "name": "Test %d" % n,
+            })
 
     def new_record(self):
         return self.Model.create(self.report_vals)
@@ -65,11 +87,8 @@ class TestReport(HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report = self.env['ir.actions.report.xml'].search([
-                ('report_type', '=', 'qweb-pdf'),
-            ], limit=1)
-            records = self.env[report.model].search([], limit=5)
-            self.env['report'].get_pdf(records.ids, report.report_name)
+            self.Model.get_pdf(
+                self.partners.ids, self.report.report_name)
             print_document.assert_not_called()
 
     def test_get_pdf_printable(self):
@@ -78,52 +97,36 @@ class TestReport(HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report = self.env['ir.actions.report.xml'].search([
-                ('report_type', '=', 'qweb-pdf'),
-            ], limit=1)
-            report.property_printing_action_id.action_type = 'server'
-            report.printing_printer_id = self.new_printer()
-            records = self.env[report.model].search([], limit=5)
-            document = self.env['report'].get_pdf(
-                records.ids, report.report_name)
+            self.report.property_printing_action_id.action_type = 'server'
+            self.report.printing_printer_id = self.new_printer()
+            document = self.Model.get_pdf(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once_with(
-                report, document, report.report_type)
+                self.report, document, self.report.report_type)
 
     def test_print_document_not_printable(self):
         """ It should print the report, regardless of the defined behaviour """
-        report = self.env['ir.actions.report.xml'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        report.printing_printer_id = self.new_printer()
-        records = self.env[report.model].search([], limit=5)
-
+        self.report.printing_printer_id = self.new_printer()
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.env['report'].print_document(records.ids, report.report_name)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
     def test_print_document_printable(self):
         """ It should print the report, regardless of the defined behaviour """
-        report = self.env['ir.actions.report.xml'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        report.property_printing_action_id.action_type = 'server'
-        report.printing_printer_id = self.new_printer()
-        records = self.env[report.model].search([], limit=5)
-
+        self.report.property_printing_action_id.action_type = 'server'
+        self.report.printing_printer_id = self.new_printer()
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.env['report'].print_document(records.ids, report.report_name)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
     def test_print_document_no_printer(self):
         """ It should raise an error """
-        report = self.env['ir.actions.report.xml'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        records = self.env[report.model].search([], limit=5)
-
         with self.assertRaises(exceptions.UserError):
-            self.env['report'].print_document(records.ids, report.report_name)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)

--- a/base_report_to_printer/tests/test_res_users.py
+++ b/base_report_to_printer/tests/test_res_users.py
@@ -2,10 +2,11 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import common
 
-
-class TestResUsers(TransactionCase):
+@common.at_install(False)
+@common.post_install(True)
+class TestResUsers(common.TransactionCase):
 
     def setUp(self):
         super(TestResUsers, self).setUp()

--- a/base_report_to_printer/tests/test_res_users.py
+++ b/base_report_to_printer/tests/test_res_users.py
@@ -4,6 +4,7 @@
 
 from odoo.tests import common
 
+
 @common.at_install(False)
 @common.post_install(True)
 class TestResUsers(common.TransactionCase):


### PR DESCRIPTION
If the test was run in a database with the `account` module installed, they were failing for 2 reasons:

- It was searching for the first report it could find, with the first 5 records to report. This made it load the `account.report_agedpartnerbalance` report, which caused a fake `TypeError: 'NoneType' object has no attribute '__getitem__'` error.
- It was running tests without loading the full module graph, thus not getting the default value for the new required `invoice_warn` field.

Now tests are run in `post_install` mode to load full module graph, and they use stateless data.

@Tecnativa