### PR TITLE
[FIX] base_report_to_printer: Stateless tests

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -105,6 +105,7 @@ Contributors
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Dave Lasley <dave@laslabs.com>
 * Sylvain Garancher <sylvain.garancher@syleam.fr>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2007 Ferran Pegueroles <ferran@pegueroles.com>
 # Copyright (c) 2009 Albert Cervera i Areny <albert@nan-tic.com>
 # Copyright (C) 2011 Agile Business Group sagl (<http://www.agilebg.com>)

--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2007 Ferran Pegueroles <ferran@pegueroles.com>
 # Copyright (c) 2009 Albert Cervera i Areny <albert@nan-tic.com>
 # Copyright (C) 2011 Agile Business Group sagl (<http://www.agilebg.com>)

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2007 Ferran Pegueroles <ferran@pegueroles.com>
 # Copyright (c) 2009 Albert Cervera i Areny <albert@nan-tic.com>
 # Copyright (C) 2011 Agile Business Group sagl (<http://www.agilebg.com>)

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -129,7 +129,6 @@ class IrActionsReport(models.Model):
             return True
         return False
 
-    @api.model
     def render_qweb_pdf(self, docids, data=None):
         """ Generate a PDF and returns it.
 

--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2007 Ferran Pegueroles <ferran@pegueroles.com>
 # Copyright (c) 2009 Albert Cervera i Areny <albert@nan-tic.com>
 # Copyright (C) 2011 Agile Business Group sagl (<http://www.agilebg.com>)

--- a/base_report_to_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_printer/tests/test_ir_actions_report.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 LasLabs Inc.
 # Copyright 2016 SYLEAM
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/base_report_to_printer/tests/test_printing_printer.py
+++ b/base_report_to_printer/tests/test_printing_printer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -35,7 +35,7 @@ class TestReport(common.HttpCase):
             </t>""",
         })
         self.report_imd.res_id = self.report_view.id
-        self.report = self.env["ir.actions.report.xml"].create({
+        self.report = self.env["ir.actions.report"].create({
             "name": "Test",
             "report_type": "qweb-pdf",
             "model": "res.partner",

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -19,7 +19,6 @@ class TestReport(common.HttpCase):
             'model': 'ir.actions.report',
             'report_name': 'Test Report',
         }
-        self.report_vals = {}
         self.report_imd = self.env["ir.model.data"].create({
             "name": "test",
             "module": "base_report_to_printer",

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -1,17 +1,15 @@
 # Copyright 2016 LasLabs Inc.
+# Copyright 2017 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import mock
-from odoo.tests.common import HttpCase
+from odoo.tests import common
 from odoo import exceptions
 
 
-class StopTest(Exception):
-    pass
-
-
-class TestReport(HttpCase):
-
+@common.at_install(False)
+@common.post_install(True)
+class TestReport(common.HttpCase):
     def setUp(self):
         super(TestReport, self).setUp()
         self.Model = self.env['ir.actions.report']
@@ -21,6 +19,33 @@ class TestReport(HttpCase):
             'model': 'ir.actions.report',
             'report_name': 'Test Report',
         }
+        self.report_vals = {}
+        self.report_imd = self.env["ir.model.data"].create({
+            "name": "test",
+            "module": "base_report_to_printer",
+            "model": "ir.ui.view",
+        })
+        self.report_view = self.env["ir.ui.view"].create({
+            "name": "Test",
+            "type": "qweb",
+            "xml_id": "base_report_to_printer.test",
+            "model_data_id": self.report_imd.id,
+            "arch": """<t t-name="base_report_to_printer.test">
+                <div>Test</div>
+            </t>""",
+        })
+        self.report_imd.res_id = self.report_view.id
+        self.report = self.env["ir.actions.report.xml"].create({
+            "name": "Test",
+            "report_type": "qweb-pdf",
+            "model": "res.partner",
+            "report_name": "base_report_to_printer.test",
+        })
+        self.partners = self.env["res.partner"]
+        for n in range(5):
+            self.partners += self.env["res.partner"].create({
+                "name": "Test %d" % n,
+            })
 
     def new_record(self):
         return self.Model.create(self.report_vals)
@@ -68,11 +93,8 @@ class TestReport(HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report = self.env['ir.actions.report'].search([
-                ('report_type', '=', 'qweb-pdf'),
-            ], limit=1)
-            records = self.env[report.model].search([], limit=5)
-            report.render_qweb_pdf(records.ids)
+            self.Model.get_pdf(
+                self.partners.ids, self.report.report_name)
             print_document.assert_not_called()
 
     def test_render_qweb_pdf_printable(self):
@@ -81,52 +103,36 @@ class TestReport(HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report = self.env['ir.actions.report'].search([
-                ('report_type', '=', 'qweb-pdf'),
-            ], limit=1)
-            report.property_printing_action_id.action_type = 'server'
-            report.printing_printer_id = self.new_printer()
-            records = self.env[report.model].search([], limit=5)
-            document, doc_format = report.render_qweb_pdf(records.ids)
+            self.report.property_printing_action_id.action_type = 'server'
+            self.report.printing_printer_id = self.new_printer()
+            document = self.Model.get_pdf(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once_with(
-                report, document,
-                action='server', doc_format='qweb-pdf', tray=False)
+                self.report, document, self.report.report_type)
 
     def test_print_document_not_printable(self):
         """ It should print the report, regardless of the defined behaviour """
-        report = self.env['ir.actions.report'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        report.printing_printer_id = self.new_printer()
-        records = self.env[report.model].search([], limit=5)
-
+        self.report.printing_printer_id = self.new_printer()
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report.print_document(records.ids)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
     def test_print_document_printable(self):
         """ It should print the report, regardless of the defined behaviour """
-        report = self.env['ir.actions.report'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        report.property_printing_action_id.action_type = 'server'
-        report.printing_printer_id = self.new_printer()
-        records = self.env[report.model].search([], limit=5)
-
+        self.report.property_printing_action_id.action_type = 'server'
+        self.report.printing_printer_id = self.new_printer()
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            report.print_document(records.ids)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
     def test_print_document_no_printer(self):
         """ It should raise an error """
-        report = self.env['ir.actions.report'].search([
-            ('report_type', '=', 'qweb-pdf'),
-        ], limit=1)
-        records = self.env[report.model].search([], limit=5)
-
         with self.assertRaises(exceptions.UserError):
-            report.print_document(records.ids)
+            self.Model.print_document(
+                self.partners.ids, self.report.report_name)

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -34,7 +34,7 @@ class TestReport(common.HttpCase):
             </t>""",
         })
         self.report_imd.res_id = self.report_view.id
-        self.report = self.env["ir.actions.report"].create({
+        self.report = self.Model.create({
             "name": "Test",
             "report_type": "qweb-pdf",
             "model": "res.partner",
@@ -92,7 +92,7 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.Model.get_pdf(
+            self.report.get_pdf(
                 self.partners.ids, self.report.report_name)
             print_document.assert_not_called()
 
@@ -104,7 +104,7 @@ class TestReport(common.HttpCase):
                         'print_document') as print_document:
             self.report.property_printing_action_id.action_type = 'server'
             self.report.printing_printer_id = self.new_printer()
-            document = self.Model.get_pdf(
+            document = self.report.get_pdf(
                 self.partners.ids, self.report.report_name)
             print_document.assert_called_once_with(
                 self.report, document, self.report.report_type)
@@ -115,7 +115,7 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.Model.print_document(
+            self.report.print_document(
                 self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
@@ -126,12 +126,12 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.Model.print_document(
+            self.report.print_document(
                 self.partners.ids, self.report.report_name)
             print_document.assert_called_once()
 
     def test_print_document_no_printer(self):
         """ It should raise an error """
         with self.assertRaises(exceptions.UserError):
-            self.Model.print_document(
+            self.report.print_document(
                 self.partners.ids, self.report.report_name)

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -92,8 +92,7 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.report.get_pdf(
-                self.partners.ids, self.report.report_name)
+            self.report.render_qweb_pdf(self.partners.ids)
             print_document.assert_not_called()
 
     def test_render_qweb_pdf_printable(self):
@@ -104,10 +103,10 @@ class TestReport(common.HttpCase):
                         'print_document') as print_document:
             self.report.property_printing_action_id.action_type = 'server'
             self.report.printing_printer_id = self.new_printer()
-            document = self.report.get_pdf(
-                self.partners.ids, self.report.report_name)
+            document = self.report.render_qweb_pdf(self.partners.ids)
             print_document.assert_called_once_with(
-                self.report, document, self.report.report_type)
+                self.report, document[0],
+                action='server', doc_format='qweb-pdf', tray=False)
 
     def test_print_document_not_printable(self):
         """ It should print the report, regardless of the defined behaviour """
@@ -115,8 +114,7 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.report.print_document(
-                self.partners.ids, self.report.report_name)
+            self.report.print_document(self.partners.ids)
             print_document.assert_called_once()
 
     def test_print_document_printable(self):
@@ -126,12 +124,10 @@ class TestReport(common.HttpCase):
         with mock.patch('odoo.addons.base_report_to_printer.models.'
                         'printing_printer.PrintingPrinter.'
                         'print_document') as print_document:
-            self.report.print_document(
-                self.partners.ids, self.report.report_name)
+            self.report.print_document(self.partners.ids)
             print_document.assert_called_once()
 
     def test_print_document_no_printer(self):
         """ It should raise an error """
         with self.assertRaises(exceptions.UserError):
-            self.report.print_document(
-                self.partners.ids, self.report.report_name)
+            self.report.print_document(self.partners.ids)

--- a/base_report_to_printer/tests/test_res_users.py
+++ b/base_report_to_printer/tests/test_res_users.py
@@ -1,10 +1,12 @@
 # Copyright 2016 LasLabs Inc.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import common
 
 
-class TestResUsers(TransactionCase):
+@common.at_install(False)
+@common.post_install(True)
+class TestResUsers(common.TransactionCase):
 
     def setUp(self):
         super(TestResUsers, self).setUp()


### PR DESCRIPTION
WIP until merged:

- [x] #122 (this is its forward-port)

If the test was run in a database with the `account` module installed, they were failing for 2 reasons:

- It was searching for the first report it could find, with the first 5 records to report. This made it load the `account.report_agedpartnerbalance` report, which caused a fake `TypeError: 'NoneType' object has no attribute '__getitem__'` error.
- It was running tests without loading the full module graph, thus not getting the default value for the new required `invoice_warn` field.

Now tests are run in `post_install` mode to load full module graph, and they use stateless data.

@Tecnativa