### PR TITLE
[FIX] Allow to generate printing options without a report

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -156,9 +156,6 @@ class PrintingPrinter(models.Model):
     @api.multi
     def print_options(self, report=None, **print_opts):
         options = {}
-        if not report:
-            return options
-
         for option, value in print_opts.items():
             try:
                 options.update(getattr(

--- a/base_report_to_printer/tests/test_printing_printer.py
+++ b/base_report_to_printer/tests/test_printing_printer.py
@@ -71,7 +71,7 @@ class TestPrintingPrinter(TransactionCase):
         # with tests in test_printing_printer_tray from when modules merged
         report = self.env['ir.actions.report'].search([], limit=1)
         self.assertEqual(self.Model.print_options(
-            report, doc_format='raw'), {'raw': 'True'}
+            doc_format='raw'), {'raw': 'True'}
         )
         self.assertEqual(self.Model.print_options(
             report, doc_format='pdf', copies=2), {'copies': '2'}


### PR DESCRIPTION
The report can be `None` when using modules like `printer_zpl2`.
In these case, we could need to add some printing options, like the `raw` format.