### PR TITLE
[IMP] base_report_to_printer: existing printers migration

### DIFF
--- a/base_report_to_printer/migrations/9.0.2.0.0/post-10-create_server_record.py
+++ b/base_report_to_printer/migrations/9.0.2.0.0/post-10-create_server_record.py
@@ -16,4 +16,5 @@ def migrate(cr, v):
             'name': config.get('cups_host', 'localhost'),
             'address': config.get('cups_host', 'localhost'),
             'port': config.get('cups_port', 631),
+            'printer_ids': [(6, 0, env['printing.printer'].search([]).ids)],
         })


### PR DESCRIPTION
- Avoid duplicating printers when `action_update_printers()` is hit for the first time coming from a previous version.

cc @Tecnativa