### PR TITLE
[9.0][10.0][11.0] [FIX] user access to printer objects

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': "Report to printer",
-    'version': '10.0.1.0.2',
+    'version': '10.0.1.0.3',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
               " LasLabs, Odoo Community Association (OCA)",

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -7,6 +7,7 @@
     </record>
     <record id="printing_group_user" model="res.groups">
       <field name="name">Printing / Print User</field>
+      <field name="users" eval="[(4, ref('base.group_user'))]"/>
     </record>
     <record id="printing_server_group_manager" model="ir.model.access">
       <field name="name">Printing Server Manager</field>


### PR DESCRIPTION
#134 
This was default behavior in v8 where there was no specific group on the read access of these objects.
The group was created in v9 so all versions upwards are affected.