### PR TITLE
[10.0][FIX] base_report_to_printer: Loss report_copies context

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': "Report to printer",
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.0.1',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN, "
               "LasLabs, Tecnativa, Odoo Community Association (OCA)",

--- a/base_report_to_printer/models/report.py
+++ b/base_report_to_printer/models/report.py
@@ -24,6 +24,7 @@ class Report(models.Model):
             report_name,
             document,
             report.report_type,
+            copies=self.env.context.get('report_copies')
         )
 
     @api.multi


### PR DESCRIPTION
In this call the report_copies context is lost
cc @Tecnativa