### PR TITLE
[FIX] printer_zpl2: don't take the bin_size during the onchange

### DIFF
--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -151,7 +151,9 @@ class PrintingLabelZpl2(models.Model):
                         component.diagonal_orientation,
                     })
             elif component.component_type == 'graphic':
-                image = component.graphic_image or data
+                # During the on_change don't take the bin_size
+                image = component.with_context(bin_size_graphic_image=False)\
+                    .graphic_image or data
                 pil_image = Image.open(io.BytesIO(
                     base64.b64decode(image))).convert('RGB')
                 if component.width and component.height:


### PR DESCRIPTION
It fix an issue when you use the Labelary Mode if case you have change a component with an image.

fix an issue of the framework : https://github.com/odoo/odoo/issues/22282#issuecomment-382372340

cc @sylvain-garancher 