### PR TITLE
[ADD] label_zpl2 and make printer_zpl2 depend to it

### DIFF
--- a/label_zpl2/README.rst
+++ b/label_zpl2/README.rst
@@ -2,20 +2,27 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-=====================
-ZPL II Label printing
-=====================
+============
+ZPL II Label
+============
 
-This module extends the **Report to printer** (``base_report_to_printer``)
-module to add a ZPL II label printing feature.
+This module adds the possibility to define printing labels in the
+Zebra Programming Language (ZPL II).
 
-This module is meant to be used as a base for module development, and does not provide a GUI on its own.
-See below for more details.
+See https://en.wikipedia.org/wiki/Zebra_(programming_language)
+
+This module is meant to be used as a base for module development, and does
+not provide a GUI on its own. See below for more details.
 
 Installation
 ============
 
-Nothing special, just install the module.
+Install python module 'zpl2' - https://pypi.org/project/zpl2
+
+.. code-block:: bash
+
+   sudo pip install zpl2
+
 
 Configuration
 =============
@@ -30,7 +37,8 @@ To configure this module, you need to:
 Usage
 =====
 
-To render a label, you need to call use the label printing method from anywhere (other modules, server actions, etc.).
+To render a label, you need to call use the label printing method from
+anywhere (other modules, server actions, etc.).
 
 .. code-block:: python
 
@@ -45,7 +53,8 @@ To render a label, you need to call use the label printing method from anywhere 
 Known issues / Roadmap
 ======================
 
-* Develop a "Designer" view in a separate module, to allow drawing labels with simple mouse clicks/drags
+* Develop a "Designer" view in a separate module, to allow drawing labels
+  with simple mouse clicks/drags
 
 Bug Tracker
 ===========

--- a/label_zpl2/README.rst
+++ b/label_zpl2/README.rst
@@ -69,6 +69,7 @@ Contributors
 * Sylvain Garancher <sylvain.garancher@syleam.fr>
 * Florent de Labarre
 * Jos De Graeve <Jos.DeGraeve@apertoso.be>
+* Enric Tobella <etobella@creublanca.es>
 
 Maintainer
 ----------

--- a/label_zpl2/README.rst
+++ b/label_zpl2/README.rst
@@ -1,0 +1,86 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================
+ZPL II Label printing
+=====================
+
+This module extends the **Report to printer** (``base_report_to_printer``)
+module to add a ZPL II label printing feature.
+
+This module is meant to be used as a base for module development, and does not provide a GUI on its own.
+See below for more details.
+
+Installation
+============
+
+Nothing special, just install the module.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to *Settings > Labels > ZPL II Labels*
+#. Create new labels
+#. Import ZPL2 code
+#. Use the Test Mode tab during the creation
+
+Usage
+=====
+
+To render a label, you need to call use the label printing method from anywhere (other modules, server actions, etc.).
+
+.. code-block:: python
+
+    # Example : Render the label of a product
+    self.env['printing.label.zpl2'].browse(label_id).render_label(
+        self.env['product.product'].browse(product_id))
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/144/11.0
+
+Known issues / Roadmap
+======================
+
+* Develop a "Designer" view in a separate module, to allow drawing labels with simple mouse clicks/drags
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/report-print-send/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Sylvain Garancher <sylvain.garancher@syleam.fr>
+* Florent de Labarre
+* Jos De Graeve <Jos.DeGraeve@apertoso.be>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/label_zpl2/__init__.py
+++ b/label_zpl2/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizard

--- a/label_zpl2/__manifest__.py
+++ b/label_zpl2/__manifest__.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Label ZPL II',
+    'version': '11.0.1.0.0',
+    'category': 'Printer',
+    'author': 'SYLEAM, Apertoso NV, Odoo Community Association (OCA)',
+    'website': 'http://www.syleam.fr/',
+    'license': 'AGPL-3',
+    'external_dependencies': {
+        'python': ['zpl2'],
+    },
+    'depends': [
+        'base', 'web'
+    ],
+    'data': [
+        'security/security.xml',
+        'security/ir.model.access.csv',
+        'views/printing_label_zpl2.xml',
+        'wizard/wizard_import_zpl2.xml',
+    ],
+    'installable': True,
+}

--- a/label_zpl2/models/__init__.py
+++ b/label_zpl2/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import printing_label_zpl2_component
+from . import printing_label_zpl2

--- a/label_zpl2/models/printing_label_zpl2.py
+++ b/label_zpl2/models/printing_label_zpl2.py
@@ -1,0 +1,325 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import time
+import base64
+import datetime
+import io
+import logging
+import requests
+from PIL import Image, ImageOps
+from odoo import api, exceptions, fields, models, _
+from odoo.tools.safe_eval import safe_eval
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import zpl2
+except ImportError:
+    _logger.debug('Cannot `import zpl2`.')
+
+
+class PrintingLabelZpl2(models.Model):
+    _name = 'printing.label.zpl2'
+    _description = 'ZPL II Label'
+    _order = 'model_id, name, id'
+
+    name = fields.Char(required=True, help='Label Name.')
+    active = fields.Boolean(default=True)
+    description = fields.Char(help='Long description for this label.')
+    model_id = fields.Many2one(
+        comodel_name='ir.model', string='Model', required=True,
+        help='Model used to print this label.')
+    origin_x = fields.Integer(
+        required=True, default=10,
+        help='Origin point of the contents in the label, X coordinate.')
+    origin_y = fields.Integer(
+        required=True, default=10,
+        help='Origin point of the contents in the label, Y coordinate.')
+    width = fields.Integer(
+        required=True, default=480,
+        help='Width of the label, will be set on the printer before printing.')
+    component_ids = fields.One2many(
+        comodel_name='printing.label.zpl2.component', inverse_name='label_id',
+        string='Label Components',
+        help='Components which will be printed on the label.')
+    restore_saved_config = fields.Boolean(
+        string="Restore printer's configuration",
+        help="Restore printer's saved configuration and end of each label ",
+        default=True)
+    test_labelary_mode = fields.Boolean(string='Mode Labelary')
+    record_id = fields.Integer(string='Record ID', default=1)
+    extra = fields.Text(string="Extra", default='{}')
+    labelary_image = fields.Binary(string='Image from Labelary', readonly=True)
+    labelary_dpmm = fields.Selection(
+        selection=[
+            ('6dpmm', '6dpmm (152 pdi)'),
+            ('8dpmm', '8dpmm (203 dpi)'),
+            ('12dpmm', '12dpmm (300 pdi)'),
+            ('24dpmm', '24dpmm (600 dpi)'),
+        ], string='Print density', required=True, default='8dpmm')
+    labelary_width = fields.Float(string='Width in mm', default=140)
+    labelary_height = fields.Float(string='Height in mm', default=70)
+
+    def _generate_zpl2_components_data(
+            self, label_data, record, page_number=1, page_count=1,
+            label_offset_x=0, label_offset_y=0, **extra):
+        self.ensure_one()
+
+        # Add all elements to print in a list of tuples :
+        #   [(component, data, offset_x, offset_y)]
+        to_print = []
+        for component in self.component_ids:
+            eval_args = extra
+            eval_args.update({
+                'object': record,
+                'page_number': str(page_number + 1),
+                'page_count': str(page_count),
+                'time': time,
+                'datetime': datetime,
+            })
+            data = safe_eval(component.data, eval_args) or ''
+
+            # Generate a list of elements if the component is repeatable
+            for idx in range(
+                    component.repeat_offset,
+                    component.repeat_offset + component.repeat_count):
+                printed_data = data
+                # Pick the right value if data is a collection
+                if isinstance(data, (list, tuple, set, models.BaseModel)):
+                    # If we reached the end of data, quit the loop
+                    if idx >= len(data):
+                        break
+
+                    # Set the real data to display
+                    printed_data = data[idx]
+
+                position = idx - component.repeat_offset
+                to_print.append((
+                    component, printed_data,
+                    label_offset_x + component.repeat_offset_x * position,
+                    label_offset_y + component.repeat_offset_y * position,
+                ))
+
+        for (component, data, offset_x, offset_y) in to_print:
+            component_offset_x = component.origin_x + offset_x
+            component_offset_y = component.origin_y + offset_y
+            if component.component_type == 'text':
+                barcode_arguments = dict([
+                    (field_name, component[field_name])
+                    for field_name in [
+                        zpl2.ARG_FONT,
+                        zpl2.ARG_ORIENTATION,
+                        zpl2.ARG_HEIGHT,
+                        zpl2.ARG_WIDTH,
+                        zpl2.ARG_REVERSE_PRINT,
+                        zpl2.ARG_IN_BLOCK,
+                        zpl2.ARG_BLOCK_WIDTH,
+                        zpl2.ARG_BLOCK_LINES,
+                        zpl2.ARG_BLOCK_SPACES,
+                        zpl2.ARG_BLOCK_JUSTIFY,
+                        zpl2.ARG_BLOCK_LEFT_MARGIN,
+                    ]
+                ])
+                label_data.font_data(
+                    component_offset_x, component_offset_y,
+                    barcode_arguments, data)
+            elif component.component_type == 'zpl2_raw':
+                label_data._write_command(data)
+            elif component.component_type == 'rectangle':
+                label_data.graphic_box(
+                    component_offset_x, component_offset_y, {
+                        zpl2.ARG_WIDTH: component.width,
+                        zpl2.ARG_HEIGHT: component.height,
+                        zpl2.ARG_THICKNESS: component.thickness,
+                        zpl2.ARG_COLOR: component.color,
+                        zpl2.ARG_ROUNDING: component.rounding,
+                    })
+            elif component.component_type == 'diagonal':
+                label_data.graphic_diagonal_line(
+                    component_offset_x, component_offset_y, {
+                        zpl2.ARG_WIDTH: component.width,
+                        zpl2.ARG_HEIGHT: component.height,
+                        zpl2.ARG_THICKNESS: component.thickness,
+                        zpl2.ARG_COLOR: component.color,
+                        zpl2.ARG_DIAGONAL_ORIENTATION:
+                        component.diagonal_orientation,
+                    })
+            elif component.component_type == 'graphic':
+                image = component.graphic_image or data
+                pil_image = Image.open(io.BytesIO(
+                    base64.b64decode(image))).convert('RGB')
+                if component.width and component.height:
+                    pil_image = pil_image.resize(
+                        (component.width, component.height))
+
+                # Invert the colors
+                if component.reverse_print:
+                    pil_image = ImageOps.invert(pil_image)
+
+                # Rotation (PIL rotates counter clockwise)
+                if component.orientation == zpl2.ORIENTATION_ROTATED:
+                    pil_image = pil_image.transpose(Image.ROTATE_270)
+                elif component.orientation == zpl2.ORIENTATION_INVERTED:
+                    pil_image = pil_image.transpose(Image.ROTATE_180)
+                elif component.orientation == zpl2.ORIENTATION_BOTTOM_UP:
+                    pil_image = pil_image.transpose(Image.ROTATE_90)
+
+                label_data.graphic_field(
+                    component_offset_x, component_offset_y,
+                    pil_image
+                )
+            elif component.component_type == 'circle':
+                label_data.graphic_circle(
+                    component_offset_x, component_offset_y, {
+                        zpl2.ARG_DIAMETER: component.width,
+                        zpl2.ARG_THICKNESS: component.thickness,
+                        zpl2.ARG_COLOR: component.color,
+                    })
+            elif component.component_type == 'sublabel':
+                component_offset_x += component.sublabel_id.origin_x
+                component_offset_y += component.sublabel_id.origin_y
+                component.sublabel_id._generate_zpl2_components_data(
+                    label_data, data,
+                    label_offset_x=component_offset_x,
+                    label_offset_y=component_offset_y)
+            else:
+                if component.component_type == zpl2.BARCODE_QR_CODE:
+                    # Adding Control Arguments to QRCode data Label
+                    data = 'MM,A{}'.format(data)
+
+                barcode_arguments = dict([
+                    (field_name, component[field_name])
+                    for field_name in [
+                        zpl2.ARG_ORIENTATION,
+                        zpl2.ARG_CHECK_DIGITS,
+                        zpl2.ARG_HEIGHT,
+                        zpl2.ARG_INTERPRETATION_LINE,
+                        zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+                        zpl2.ARG_SECURITY_LEVEL,
+                        zpl2.ARG_COLUMNS_COUNT,
+                        zpl2.ARG_ROWS_COUNT,
+                        zpl2.ARG_TRUNCATE,
+                        zpl2.ARG_MODULE_WIDTH,
+                        zpl2.ARG_BAR_WIDTH_RATIO,
+                        zpl2.ARG_MODEL,
+                        zpl2.ARG_MAGNIFICATION_FACTOR,
+                        zpl2.ARG_ERROR_CORRECTION,
+                        zpl2.ARG_MASK_VALUE,
+                    ]
+                ])
+                label_data.barcode_data(
+                    component.origin_x + offset_x,
+                    component.origin_y + offset_y,
+                    component.component_type, barcode_arguments, data)
+
+    def _generate_zpl2_data(self, record, page_count=1, **extra):
+        self.ensure_one()
+        label_data = zpl2.Zpl2()
+
+        labelary_emul = extra.get('labelary_emul', False)
+        for page_number in range(page_count):
+            # Initialize printer's configuration
+            label_data.label_start()
+            if not labelary_emul:
+                label_data.print_width(self.width)
+            label_data.label_encoding()
+
+            label_data.label_home(self.origin_x, self.origin_y)
+
+            self._generate_zpl2_components_data(
+                label_data, record, page_number=page_number,
+                page_count=page_count, **extra)
+
+            # Restore printer's configuration and end the label
+            if self.restore_saved_config:
+                label_data.configuration_update(zpl2.CONF_RECALL_LAST_SAVED)
+            label_data.label_end()
+
+        return label_data.output()
+
+    def render_label(self, record, page_count=1, **extra):
+        res = ""
+        for label in self:
+            if record._name != label.model_id.model:
+                raise exceptions.UserError(
+                    _('This label cannot be used on {model}').format(
+                        model=record._name))
+            if len(res) > 0:
+                res += "\n"
+            # Send the label to printer
+            res += label._generate_zpl2_data(
+                record, page_count=page_count, **extra).decode('utf-8')
+        return res
+
+    def import_zpl2(self):
+        self.ensure_one()
+        return {
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'wizard.import.zpl2',
+            'type': 'ir.actions.act_window',
+            'target': 'new',
+            'context': {'default_label_id': self.id},
+        }
+
+    def _get_record(self):
+        self.ensure_one()
+        Obj = self.env[self.model_id.model]
+        record = Obj.search([('id', '=', self.record_id)], limit=1)
+        if not record:
+            record = Obj.search([], limit=1, order='id desc')
+            self.record_id = record.id
+        return record
+
+    @api.onchange(
+        'record_id', 'labelary_dpmm', 'labelary_width', 'labelary_height',
+        'component_ids', 'origin_x', 'origin_y')
+    def _on_change_labelary(self):
+        self.ensure_one()
+        if not(self.test_labelary_mode and self.record_id and
+                self.labelary_width and self.labelary_height and
+                self.labelary_dpmm and self.component_ids):
+            return
+        record = self._get_record()
+        if record:
+            # If case there an error (in the data field with the safe_eval
+            # for exemple) the new component or the update is not lost.
+            try:
+                url = 'http://api.labelary.com/v1/printers/' \
+                    '{dpmm}/labels/{width}x{height}/0/'
+                width = round(self.labelary_width / 25.4, 2)
+                height = round(self.labelary_height / 25.4, 2)
+                url = url.format(
+                    dpmm=self.labelary_dpmm, width=width, height=height)
+                extra = safe_eval(self.extra, {'env': self.env})
+                zpl_file = self._generate_zpl2_data(
+                    record, labelary_emul=True, **extra)
+                files = {'file': zpl_file}
+                headers = {'Accept': 'image/png'}
+                response = requests.post(
+                    url, headers=headers, files=files, stream=True)
+                if response.status_code == 200:
+                    # Add a padd
+                    im = Image.open(io.BytesIO(response.content))
+                    im_size = im.size
+                    new_im = Image.new(
+                        'RGB', (im_size[0] + 2, im_size[1] + 2),
+                        (164, 164, 164))
+                    new_im.paste(im, (1, 1))
+                    imgByteArr = io.BytesIO()
+                    new_im.save(imgByteArr, format='PNG')
+                    self.labelary_image = base64.b64encode(
+                        imgByteArr.getvalue())
+                else:
+                    return {'warning': {
+                        'title': _('Error with Labelary API.'),
+                        'message': response.status_code,
+                    }}
+
+            except Exception as e:
+                self.labelary_image = False
+                return {'warning': {
+                    'title': _('Some thing is wrong.'),
+                    'message': e,
+                }}

--- a/label_zpl2/models/printing_label_zpl2_component.py
+++ b/label_zpl2/models/printing_label_zpl2_component.py
@@ -1,0 +1,184 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import zpl2
+except ImportError:
+    _logger.debug('Cannot `import zpl2`.')
+
+DEFAULT_PYTHON_CODE = """# Python One-Liners
+#  - object: record on which the action is triggered; may be be void
+#  - page_number: Current Page
+#  - page_count: Total Page
+#  - time, datetime: Python libraries
+#  Exemple : object.name
+
+""
+"""
+
+
+class PrintingLabelZpl2Component(models.Model):
+    _name = 'printing.label.zpl2.component'
+    _description = 'ZPL II Label Component'
+    _order = 'sequence, id'
+
+    label_id = fields.Many2one(
+        comodel_name='printing.label.zpl2', string='Label',
+        required=True, ondelete='cascade', help='Label using this component.')
+    sequence = fields.Integer(help='Order used to print the elements.')
+    name = fields.Char(required=True, help='Name of the component.')
+    origin_x = fields.Integer(
+        required=True, default=10,
+        help='Origin point of the component in the label, X coordinate.')
+    origin_y = fields.Integer(
+        required=True, default=10,
+        help='Origin point of the component in the label, Y coordinate.')
+    component_type = fields.Selection(
+        selection=[
+            ('text', 'Text'),
+            ('rectangle', 'Rectangle / Line'),
+            ('diagonal', 'Diagonal Line'),
+            ('circle', 'Circle'),
+            ('graphic', 'Graphic'),
+            (zpl2.BARCODE_CODE_11, 'Code 11'),
+            (zpl2.BARCODE_INTERLEAVED_2_OF_5, 'Interleaved 2 of 5'),
+            (zpl2.BARCODE_CODE_39, 'Code 39'),
+            (zpl2.BARCODE_CODE_49, 'Code 49'),
+            (zpl2.BARCODE_PDF417, 'PDF417'),
+            (zpl2.BARCODE_EAN_8, 'EAN-8'),
+            (zpl2.BARCODE_UPC_E, 'UPC-E'),
+            (zpl2.BARCODE_CODE_128, 'Code 128'),
+            (zpl2.BARCODE_EAN_13, 'EAN-13'),
+            (zpl2.BARCODE_QR_CODE, 'QR Code'),
+            ('sublabel', 'Sublabel'),
+            ('zpl2_raw', 'ZPL2'),
+        ], string='Type', required=True, default='text', oldname='type',
+        help='Type of content, simple text or barcode.')
+    font = fields.Selection(
+        selection=[
+            (zpl2.FONT_DEFAULT, 'Default'),
+            (zpl2.FONT_9X5, '9x5'),
+            (zpl2.FONT_11X7, '11x7'),
+            (zpl2.FONT_18X10, '18x10'),
+            (zpl2.FONT_28X15, '28x15'),
+            (zpl2.FONT_26X13, '26x13'),
+            (zpl2.FONT_60X40, '60x40'),
+            (zpl2.FONT_21X13, '21x13'),
+        ], required=True, default=zpl2.FONT_DEFAULT,
+        help='Font to use, for text only.')
+    thickness = fields.Integer(help='Thickness of the line to draw.')
+    color = fields.Selection(
+        selection=[
+            (zpl2.COLOR_BLACK, 'Black'),
+            (zpl2.COLOR_WHITE, 'White'),
+        ], default=zpl2.COLOR_BLACK,
+        help='Color of the line to draw.')
+    orientation = fields.Selection(
+        selection=[
+            (zpl2.ORIENTATION_NORMAL, 'Normal'),
+            (zpl2.ORIENTATION_ROTATED, 'Rotated'),
+            (zpl2.ORIENTATION_INVERTED, 'Inverted'),
+            (zpl2.ORIENTATION_BOTTOM_UP, 'Read from Bottom up'),
+        ], required=True, default=zpl2.ORIENTATION_NORMAL,
+        help='Orientation of the barcode.')
+    diagonal_orientation = fields.Selection(
+        selection=[
+            (zpl2.DIAGONAL_ORIENTATION_LEFT, 'Left (\\)'),
+            (zpl2.DIAGONAL_ORIENTATION_RIGHT, 'Right (/)'),
+        ], default=zpl2.DIAGONAL_ORIENTATION_LEFT,
+        help='Orientation of the diagonal line.')
+    check_digits = fields.Boolean(
+        help='Check if you want to compute and print the check digit.')
+    height = fields.Integer(
+        help='Height of the printed component. For a text component, height '
+        'of a single character.')
+    width = fields.Integer(
+        help='Width of the printed component. For a text component, width of '
+        'a single character.')
+    rounding = fields.Integer(
+        help='Rounding of the printed rectangle corners.')
+    interpretation_line = fields.Boolean(
+        help='Check if you want the interpretation line to be printed.')
+    interpretation_line_above = fields.Boolean(
+        help='Check if you want the interpretation line to be printed above '
+        'the barcode.')
+    module_width = fields.Integer(
+        default=2, help='Module width for the barcode.')
+    bar_width_ratio = fields.Float(
+        default=3.0, help='Ratio between wide bar and narrow bar.')
+    security_level = fields.Integer(help='Security level for error detection.')
+    columns_count = fields.Integer(help='Number of data columns to encode.')
+    rows_count = fields.Integer(help='Number of rows to encode.')
+    truncate = fields.Boolean(
+        help='Check if you want to truncate the barcode.')
+    model = fields.Selection(
+        selection=[
+            (zpl2.MODEL_ORIGINAL, 'Original'),
+            (zpl2.MODEL_ENHANCED, 'Enhanced'),
+        ], default=zpl2.MODEL_ENHANCED,
+        help='Barcode model, used by some barcode types like QR Code.')
+    magnification_factor = fields.Integer(
+        default=1, help='Magnification Factor, from 1 to 10.')
+    error_correction = fields.Selection(
+        selection=[
+            (zpl2.ERROR_CORRECTION_ULTRA_HIGH, 'Ultra-high Reliability Level'),
+            (zpl2.ERROR_CORRECTION_HIGH, 'High Reliability Level'),
+            (zpl2.ERROR_CORRECTION_STANDARD, 'Standard Level'),
+            (zpl2.ERROR_CORRECTION_HIGH_DENSITY, 'High Density Level'),
+        ], required=True, default=zpl2.ERROR_CORRECTION_HIGH,
+        help='Error correction for some barcode types like QR Code.')
+    mask_value = fields.Integer(default=7, help='Mask Value, from 0 to 7.')
+    data = fields.Text(
+        default=DEFAULT_PYTHON_CODE, required=True,
+        help='Data to print on this component. Resource values can be '
+        'inserted with %(object.field_name)s.')
+    sublabel_id = fields.Many2one(
+        comodel_name='printing.label.zpl2', string='Sublabel',
+        help='Another label to include into this one as a component. '
+        'This allows to define reusable labels parts.')
+    repeat = fields.Boolean(
+        string='Repeatable',
+        help='Check this box to repeat this component on the label.')
+    repeat_offset = fields.Integer(
+        default=0,
+        help='Number of elements to skip when reading a list of elements.')
+    repeat_count = fields.Integer(
+        default=1,
+        help='Maximum count of repeats of the component.')
+    repeat_offset_x = fields.Integer(
+        help='X coordinate offset between each occurence of this component on '
+        'the label.')
+    repeat_offset_y = fields.Integer(
+        help='Y coordinate offset between each occurence of this component on '
+        'the label.')
+    reverse_print = fields.Boolean(
+        help='If checked, the data will be printed in the inverse color of '
+        'the background.')
+    in_block = fields.Boolean(
+        help='If checked, the data will be restrected in a '
+        'defined block on the label.')
+    block_width = fields.Integer(help='Width of the block.')
+    block_lines = fields.Integer(
+        default=1, help='Maximum number of lines to print in the block.')
+    block_spaces = fields.Integer(
+        help='Number of spaces added between lines in the block.')
+    block_justify = fields.Selection(
+        selection=[
+            (zpl2.JUSTIFY_LEFT, 'Left'),
+            (zpl2.JUSTIFY_CENTER, 'Center'),
+            (zpl2.JUSTIFY_JUSTIFIED, 'Justified'),
+            (zpl2.JUSTIFY_RIGHT, 'Right'),
+        ], string='Justify', required=True, default='L',
+        help='Choose how the text will be justified in the block.')
+    block_left_margin = fields.Integer(
+        string='Left Margin',
+        help='Left margin for the second and other lines in the block.')
+    graphic_image = fields.Binary(
+        string='Image', attachment=True,
+        help='This field holds a static image to print. '
+             'If not set, the data field is evaluated.')

--- a/label_zpl2/security/ir.model.access.csv
+++ b/label_zpl2/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+printing_label_zpl2_user,Printing Label ZPL2 User,model_printing_label_zpl2,label_group_user,1,0,0,0
+printing_label_zpl2_manager,Printing Label ZPL2 Manager,model_printing_label_zpl2,label_group_manager,1,1,1,1
+printing_label_zpl2_component_user,Printing Label ZPL2 Component User,model_printing_label_zpl2_component,label_group_user,1,0,0,0
+printing_label_zpl2_component_manager,Printing Label ZPL2 Component Manager,model_printing_label_zpl2_component,label_group_manager,1,1,1,1

--- a/label_zpl2/security/security.xml
+++ b/label_zpl2/security/security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<odoo noupdate="1">
+        <record id="label_group_manager" model="res.groups">
+            <field name="name">Label / Label Manager</field>
+            <field name="users" eval="[(4, ref('base.user_root'))]"/>
+        </record>
+        <record id="label_group_user" model="res.groups">
+            <field name="name">Label / Label User</field>
+        </record>
+</odoo>

--- a/label_zpl2/tests/__init__.py
+++ b/label_zpl2/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_printing_label_zpl2
+from . import test_test_mode
+from . import test_wizard_import_zpl2

--- a/label_zpl2/tests/test_printing_label_zpl2.py
+++ b/label_zpl2/tests/test_printing_label_zpl2.py
@@ -1,0 +1,1092 @@
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import zpl2
+except ImportError:
+    _logger.debug('Cannot `import zpl2`.')
+
+
+class TestPrintingLabelZpl2(TransactionCase):
+    def setUp(self):
+        super(TestPrintingLabelZpl2, self).setUp()
+        self.Model = self.env['printing.label.zpl2']
+        self.ComponentModel = self.env['printing.label.zpl2.component']
+        self.label_vals = {
+            'name': 'ZPL II Label',
+            'model_id': self.env.ref('base.model_res_partner').id,
+        }
+        self.component_vals = {
+            'name': 'ZPL II Label Component',
+        }
+        self.partner = self.env['res.partner'].create({'name': 'Partner'})
+
+    def new_label(self, vals=None):
+        values = self.label_vals.copy()
+        if vals:
+            values.update(vals)
+        return self.Model.create(values)
+
+    def new_component(self, vals=None):
+        values = self.component_vals.copy()
+        if vals:
+            values.update(vals)
+        return self.ComponentModel.create(values)
+
+    def test_empty_label_contents(self):
+        """ Check contents of an empty label """
+        label = self.new_label()
+        contents = label._generate_zpl2_data(self.partner).decode('utf-8')
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ')
+        self.assertEqual(
+            contents, label.render_label(self.partner)
+        )
+
+    def test_sublabel_label_contents(self):
+        """ Check contents of a sublabel label component """
+        sublabel = self.new_label({
+            'name': 'Sublabel',
+        })
+        data = 'Some text'
+        self.new_component({
+            'label_id': sublabel.id,
+            'data': '"' + data + '"',
+        })
+        label = self.new_label()
+        self.new_component({
+            'label_id': label.id,
+            'name': 'Sublabel contents',
+            'component_type': 'sublabel',
+            'sublabel_id': sublabel.id,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode('utf-8')
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Sublabel component position
+            # Position 30x30 because the default values are :
+            # - 10x10 for the sublabel component in the main label
+            # - 10x10 for the sublabel in the sublabel component
+            # - 10x10 for the component in the sublabel
+            '^FO30,30'
+            # Sublabel component format
+            '^A0N,10,10'
+            # Sublabel component contents
+            '^FD{contents}'
+            # Sublabel component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_repeatable_component_label_fixed_contents(self):
+        """ Check contents of a repeatable label component
+
+        Check that a fixed value is repeated each time
+        """
+        label = self.new_label({
+            'model_id': self.env.ref(
+                'label_zpl2.model_printing_label_zpl2').id,
+        })
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'data': '"' + data + '"',
+            'repeat': True,
+            'repeat_count': 3,
+            'repeat_offset_y': 15,
+        })
+        contents = label._generate_zpl2_data(label).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # First component position
+            '^FO10,10'
+            # First component format
+            '^A0N,10,10'
+            # First component contents
+            '^FD{contents}'
+            # First component end
+            '^FS\n'
+            # Second component position
+            '^FO10,25'
+            # Second component format
+            '^A0N,10,10'
+            # Second component contents
+            '^FD{contents}'
+            # Second component end
+            '^FS\n'
+            # Third component position
+            '^FO10,40'
+            # Third component format
+            '^A0N,10,10'
+            # Third component contents
+            '^FD{contents}'
+            # Third component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_repeatable_component_label_iterable_contents(self):
+        """ Check contents of a repeatable label component
+
+        Check that an iterable contents (list, tuple, etc.) is browsed
+        If the repeat_count is higher than the value length, all values are
+        displayed
+        """
+        label = self.new_label({
+            'model_id': self.env.ref(
+                'label_zpl2.model_printing_label_zpl2').id,
+        })
+        data = ['First text', 'Second text', 'Third text']
+        self.new_component({
+            'label_id': label.id,
+            'data': str(data),
+            'repeat': True,
+            'repeat_offset': 1,
+            'repeat_count': 3,
+            'repeat_offset_y': 15,
+        })
+        contents = label._generate_zpl2_data(label).decode('utf-8')
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # First component position
+            '^FO10,10'
+            # First component format
+            '^A0N,10,10'
+            # First component contents
+            '^FD{contents[1]}'
+            # First component end
+            '^FS\n'
+            # Second component position
+            '^FO10,25'
+            # Second component format
+            '^A0N,10,10'
+            # Second component contents
+            '^FD{contents[2]}'
+            # Second component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_repeatable_component_label_iterable_offset(self):
+        """ Check contents of a repeatable label component with an offset
+
+        Check that an iterable contents (list, tuple, etc.) is browsed
+        If the repeat_count is higher than the value length, all values are
+        displayed
+        """
+        label = self.new_label({
+            'model_id': self.env.ref(
+                'label_zpl2.model_printing_label_zpl2').id,
+        })
+        data = ['Text {value}'.format(value=ind) for ind in range(20)]
+        self.new_component({
+            'label_id': label.id,
+            'data': str(data),
+            'repeat': True,
+            'repeat_offset': 10,
+            'repeat_count': 3,
+            'repeat_offset_y': 15,
+        })
+        contents = label._generate_zpl2_data(label).decode('utf-8')
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # First component position
+            '^FO10,10'
+            # First component format
+            '^A0N,10,10'
+            # First component contents
+            '^FD{contents[10]}'
+            # First component end
+            '^FS\n'
+            # Second component position
+            '^FO10,25'
+            # Second component format
+            '^A0N,10,10'
+            # Second component contents
+            '^FD{contents[11]}'
+            # Second component end
+            '^FS\n'
+            # Third component position
+            '^FO10,40'
+            # Third component format
+            '^A0N,10,10'
+            # Third component contents
+            '^FD{contents[12]}'
+            # Third component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_repeatable_sublabel_contents(self):
+        """ Check contents of a repeatable sublabel label component """
+        sublabel = self.new_label({
+            'name': 'Sublabel',
+            'model_id': self.env.ref(
+                'label_zpl2.model_printing_label_zpl2_component').id,
+        })
+        self.new_component({
+            'label_id': sublabel.id,
+            'name': 'Components name',
+            'data': 'object.name',
+        })
+        self.new_component({
+            'label_id': sublabel.id,
+            'name': 'Components data',
+            'data': 'object.data',
+            'origin_x': 50,
+        })
+        label = self.new_label({
+            'model_id': self.env.ref(
+                'label_zpl2.model_printing_label_zpl2').id,
+        })
+        self.new_component({
+            'label_id': label.id,
+            'name': 'Label name',
+            'data': 'object.name',
+        })
+        self.new_component({
+            'label_id': label.id,
+            'name': 'Label components',
+            'component_type': 'sublabel',
+            'origin_x': 15,
+            'origin_y': 30,
+            'data': 'object.component_ids',
+            'sublabel_id': sublabel.id,
+            'repeat': True,
+            'repeat_count': 3,
+            'repeat_offset_y': 15,
+        })
+        contents = label._generate_zpl2_data(label).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Label name component position
+            '^FO10,10'
+            # Label name component format
+            '^A0N,10,10'
+            # Label name component contents
+            '^FD{label.name}'
+            # Label name component end
+            '^FS\n'
+            # First component name component position
+            '^FO35,50'
+            # First component name component format
+            '^A0N,10,10'
+            # First component name component contents
+            '^FD{label.component_ids[0].name}'
+            # First component name component end
+            '^FS\n'
+            # First component data component position
+            '^FO75,50'
+            # First component data component format
+            '^A0N,10,10'
+            # First component data component contents
+            '^FD{label.component_ids[0].data}'
+            # First component data component end
+            '^FS\n'
+            # Second component name component position
+            '^FO35,65'
+            # Second component name component format
+            '^A0N,10,10'
+            # Second component name component contents
+            '^FD{label.component_ids[1].name}'
+            # Second component name component end
+            '^FS\n'
+            # Second component data component position
+            '^FO75,65'
+            # Second component data component format
+            '^A0N,10,10'
+            # Second component data component contents
+            '^FD{label.component_ids[1].data}'
+            # Second component data component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(label=label))
+
+    def test_text_label_contents(self):
+        """ Check contents of a text label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'data': '"%s"' % data,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^A0N,10,10'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_reversed_text_label_contents(self):
+        """ Check contents of a text label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'data': '"' + data + '"',
+            'reverse_print': True,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^A0N,10,10'
+            # Reverse print argument
+            '^FR'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_block_text_label_contents(self):
+        """ Check contents of a text label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'data': '"' + data + '"',
+            'in_block': True,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^A0N,10,10'
+            # Block definition
+            '^FB0,1,0,L,0'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_rectangle_label_contents(self):
+        """ Check contents of a rectangle label """
+        label = self.new_label()
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'rectangle',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^GB1,1,1,B,0'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ')
+
+    def test_diagonal_line_label_contents(self):
+        """ Check contents of a diagonal line label """
+        label = self.new_label()
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'diagonal',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^GD3,3,1,B,L'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ')
+
+    def test_circle_label_contents(self):
+        """ Check contents of a circle label """
+        label = self.new_label()
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'circle',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^GC3,2,B'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ')
+
+    def test_code11_barcode_label_contents(self):
+        """ Check contents of a code 11 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_11',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B1N,N,0,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_2of5_barcode_label_contents(self):
+        """ Check contents of a interleaved 2 of 5 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'interleaved_2_of_5',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B2N,0,N,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_code39_barcode_label_contents(self):
+        """ Check contents of a code 39 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_39',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B3N,N,0,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_code49_barcode_label_contents(self):
+        """ Check contents of a code 49 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_49',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B4N,0,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_code49_barcode_label_contents_line(self):
+        """ Check contents of a code 49 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_49',
+            'data': '"' + data + '"',
+            'interpretation_line': True,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B4N,0,B'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_code49_barcode_label_contents_with_above(self):
+        """ Check contents of a code 49 barconde label
+        with interpretation line above
+        """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_49',
+            'data': '"' + data + '"',
+            'interpretation_line': True,
+            'interpretation_line_above': True,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B4N,0,A'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_pdf417_barcode_label_contents(self):
+        """ Check contents of a pdf417 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'pdf417',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B7N,0,0,0,0,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_ean8_barcode_label_contents(self):
+        """ Check contents of a ean-8 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'ean-8',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B8N,0,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_upce_barcode_label_contents(self):
+        """ Check contents of a upc-e barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'upc-e',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^B9N,0,N,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_code128_barcode_label_contents(self):
+        """ Check contents of a code 128 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'code_128',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^BCN,0,N,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_ean13_barcode_label_contents(self):
+        """ Check contents of a ean-13 barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'ean-13',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^BEN,0,N,N'
+            # Component contents
+            '^FD{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_qrcode_barcode_label_contents(self):
+        """ Check contents of a qr code barcode label """
+        label = self.new_label()
+        data = 'Some text'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'qr_code',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            # Label start
+            '^XA\n'
+            # Print width
+            '^PW480\n'
+            # UTF-8 encoding
+            '^CI28\n'
+            # Label position
+            '^LH10,10\n'
+            # Barcode default format
+            '^BY2,3.0'
+            # Component position
+            '^FO10,10'
+            # Component format
+            '^BQN,2,1,Q,7'
+            # Component contents
+            '^FDMM,A{contents}'
+            # Component end
+            '^FS\n'
+            # Recall last saved parameters
+            '^JUR\n'
+            # Label end
+            '^XZ'.format(contents=data))
+
+    def test_graphic_label_contents_blank(self):
+        """ Check contents of a image label """
+        label = self.new_label()
+        data = 'R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'graphic',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            "^XA\n"
+            "^PW480\n"
+            "^CI28\n"
+            "^LH10,10\n"
+            "^FO10,10^GFA,1.0,1.0,1.0,b'00'^FS\n"
+            "^JUR\n"
+            "^XZ")
+
+    def test_graphic_label_contents_blank_rotated(self):
+        """ Check contents of image rotated label """
+        label = self.new_label()
+        data = 'R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'graphic',
+            'data': '"' + data + '"',
+            'height': 10,
+            'width': 10,
+            'reverse_print': 1,
+            'orientation': zpl2.ORIENTATION_ROTATED,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            "^XA\n"
+            "^PW480\n"
+            "^CI28\n"
+            "^LH10,10\n"
+            "^FO10,10^GFA,20.0,20.0,2.0,"
+            "b'FFC0FFC0FFC0FFC0FFC0FFC0FFC0FFC0FFC0FFC0'^FS\n"
+            "^JUR\n"
+            "^XZ")
+
+    def test_graphic_label_contents_blank_inverted(self):
+        """ Check contents of a image inverted label """
+        label = self.new_label()
+        data = 'R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'graphic',
+            'data': '"' + data + '"',
+            'orientation': zpl2.ORIENTATION_INVERTED,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            "^XA\n"
+            "^PW480\n"
+            "^CI28\n"
+            "^LH10,10\n"
+            "^FO10,10^GFA,1.0,1.0,1.0,b'00'^FS\n"
+            "^JUR\n"
+            "^XZ")
+
+    def test_graphic_label_contents_blank_bottom(self):
+        """ Check contents of a image bottom label """
+        label = self.new_label()
+        data = 'R0lGODlhAQABAIAAAP7//wAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw=='
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'graphic',
+            'data': '"' + data + '"',
+            'orientation': zpl2.ORIENTATION_BOTTOM_UP,
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            "^XA\n"
+            "^PW480\n"
+            "^CI28\n"
+            "^LH10,10\n"
+            "^FO10,10^GFA,1.0,1.0,1.0,b'00'^FS\n"
+            "^JUR\n"
+            "^XZ")
+
+    def test_zpl2_raw_contents_blank(self):
+        """ Check contents of a image label """
+        label = self.new_label()
+        data = '^FO50,50^GB100,100,100^FS'
+        self.new_component({
+            'label_id': label.id,
+            'component_type': 'zpl2_raw',
+            'data': '"' + data + '"',
+        })
+        contents = label._generate_zpl2_data(self.partner).decode("utf-8")
+        self.assertEqual(
+            contents,
+            '^XA\n'
+            '^PW480\n'
+            '^CI28\n'
+            '^LH10,10\n'
+            '^FO50,50^GB100,100,100^FS\n'
+            '^JUR\n'
+            '^XZ')

--- a/label_zpl2/tests/test_test_mode.py
+++ b/label_zpl2/tests/test_test_mode.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2018 Florent Mirieu (<https://github.com/fmdl>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestWizardPrintRecordLabel(TransactionCase):
+    def setUp(self):
+        super(TestWizardPrintRecordLabel, self).setUp()
+        self.label = self.env['printing.label.zpl2'].create({
+            'name': 'ZPL II Label',
+            'model_id': self.env.ref('base.model_res_partner').id,
+        })
+
+    def test_get_record(self):
+        """ Check if return a record """
+        self.label.record_id = 10
+        res = self.label._get_record()
+
+        Obj = self.env[self.label.model_id.model]
+        record = Obj.search([('id', '=', self.label.record_id)], limit=1)
+        if not record:
+            record = Obj.search([], limit=1, order='id desc')
+        self.assertEqual(res, record)
+
+    def test_emulation_without_params(self):
+        """ Check if not execute next if not in this mode """
+        self.label.test_labelary_mode = False
+        self.label._on_change_labelary()
+        self.assertIs(self.label.labelary_image, None)
+
+    def test_emulation_with_bad_header(self):
+        """ Check if bad header """
+        self.label.test_labelary_mode = True
+        self.label.labelary_width = 80
+        self.label.labelary_dpmm = '8dpmm'
+        self.label.labelary_height = 10000000
+        self.env['printing.label.zpl2.component'].create({
+            'name': 'ZPL II Label',
+            'label_id': self.label.id,
+            'data': '"Test"'})
+        self.label._on_change_labelary()
+        self.assertFalse(self.label.labelary_image)
+
+    def test_emulation_with_bad_data_compute(self):
+        """ Check if bad data compute """
+        self.label.test_labelary_mode = True
+        self.label.labelary_width = 80
+        self.label.labelary_height = 30
+        self.label.labelary_dpmm = '8dpmm'
+        component = self.env['printing.label.zpl2.component'].create({
+            'name': 'ZPL II Label',
+            'label_id': self.label.id,
+            'data': 'wrong_data'})
+        self.label._on_change_labelary()
+        component.unlink()
+        self.assertIs(self.label.labelary_image, None)
+
+    def test_emulation_with_good_data(self):
+        """ Check if ok """
+        self.label.test_labelary_mode = True
+        self.label.labelary_width = 80
+        self.label.labelary_height = 30
+        self.label.labelary_dpmm = '8dpmm'
+        self.env['printing.label.zpl2.component'].create({
+            'name': 'ZPL II Label',
+            'label_id': self.label.id,
+            'data': '"good_data"', })
+        self.label._on_change_labelary()
+        self.assertTrue(self.label.labelary_image)

--- a/label_zpl2/tests/test_wizard_import_zpl2.py
+++ b/label_zpl2/tests/test_wizard_import_zpl2.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2018 Florent Mirieu (<https://github.com/fmdl>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestWizardImportZpl2(TransactionCase):
+    def setUp(self):
+        super(TestWizardImportZpl2, self).setUp()
+        self.label = self.env['printing.label.zpl2'].create({
+            'name': 'ZPL II Label',
+            'model_id': self.env.ref('base.model_res_partner').id,
+        })
+
+    def test_open_wizard(self):
+        """ open wizard from label"""
+        res = self.label.import_zpl2()
+        self.assertEqual(
+            res.get('context').get('default_label_id'),
+            self.label.id)
+
+    def test_wizard_import_zpl2(self):
+        """ Import ZPL2 from wizard """
+        zpl_data = ("^XA\n"
+                    "^CI28\n"
+                    "^LH0,0\n"
+                    "^CF0\n"
+                    "^CFA,10\n"
+                    "^CFB,10,10\n"
+                    "^FO10,10^A0N,30,30^FDTEXT^FS\n"
+                    "^BY2,3.0^FO600,60^BCN,30,N,N,N"
+                    "^FDAJFGJAGJVJVHK^FS\n"
+                    "^FO10,40^A0N,20,40^FB150,2,1,J,0^FDTEXT BLOCK^FS\n"
+                    "^FO300,10^GC100,3,B^FS\n"
+                    "^FO10,200^GB200,200,100,B,0^FS\n"
+                    "^FO10,60^GFA,16.0,16.0,2.0,"
+                    "b'FFC0FFC0FFC0FFC0FFC0FFC0FFC0FFC0'^FS\n"
+                    "^FO10,200^GB300,100,6,W,0^FS\n"
+                    "^BY2,3.0^FO300,10^B1N,N,30,N,N^FD678987656789^FS\n"
+                    "^BY2,3.0^FO300,70^B2N,30,Y,Y,N^FD567890987768^FS\n"
+                    "^BY2,3.0^FO300,120^B3N,N,30,N,N^FD98765456787656^FS\n"
+                    "^BY2,3.0^FO300,200^BQN,2,5,Q,7"
+                    "^FDMM,A876567897656787658654645678^FS\n"
+                    "^BY2,3.0^FO400,250^BER,40,Y,Y^FD9876789987654567^FS\n"
+                    "^BY2,3.0^FO350,250^B7N,20,0,0,0,N^FD8765678987656789^FS\n"
+                    "^BY2,3.0^FO700,10^B9N,20,N,N,N^FD87657890987654^FS\n"
+                    "^BY2,3.0^FO600,200^B4N,50,N^FD7654567898765678^FS\n"
+                    "^BY2,3.0^FO600,300^BEN,50,Y,Y^FD987654567890876567^FS\n"
+                    "^FO300,300^AGI,50,50^FR^FDINVERTED^FS\n"
+                    "^BY2,3.0^FO700,200^B8,50,N,N^FD987609876567^FS\n"
+                    "^JUR\n"
+                    "^XZ")
+
+        vals = {'label_id': self.label.id,
+                'delete_component': True,
+                'data': zpl_data}
+        wizard = self.env['wizard.import.zpl2'].create(vals)
+        wizard.import_zpl2()
+        self.assertEqual(
+            18,
+            len(self.label.component_ids))
+
+    def test_wizard_import_zpl2_add(self):
+        """ Import ZPL2 from wizard ADD"""
+        self.env['printing.label.zpl2.component'].create({
+            'name': 'ZPL II Label',
+            'label_id': self.label.id,
+            'data': '"data"',
+            'sequence': 10})
+        zpl_data = ("^XA\n"
+                    "^CI28\n"
+                    "^LH0,0\n"
+                    "^FO10,10^A0N,30,30^FDTEXT^FS\n"
+                    "^JUR\n"
+                    "^XZ")
+
+        vals = {'label_id': self.label.id,
+                'delete_component': False,
+                'data': zpl_data}
+        wizard = self.env['wizard.import.zpl2'].create(vals)
+        wizard.import_zpl2()
+        self.assertEqual(
+            2,
+            len(self.label.component_ids))

--- a/label_zpl2/views/printing_label_zpl2.xml
+++ b/label_zpl2/views/printing_label_zpl2.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+<!--
+    Copyright 2016 SYLEAM
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_printing_label_zpl2_tree" model="ir.ui.view">
+        <field name="model">printing.label.zpl2</field>
+        <field name="arch" type="xml">
+            <tree string="ZPL II Label">
+                <field name="name"/>
+                <field name="model_id"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_printing_label_zpl2_form" model="ir.ui.view">
+        <field name="model">printing.label.zpl2</field>
+        <field name="arch" type="xml">
+            <form string="ZPL II Label">
+                <header>
+                    <button name="import_zpl2" string="Import ZPL2" type="object"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
+                            <field name="active" widget="boolean_button" options="{&quot;terminology&quot;: &quot;archive&quot;}"/>
+                        </button>
+                    </div>
+                    <group col="4">
+                        <field name="name"/>
+                        <field name="model_id"/>
+                        <field name="description"/>
+                        <field name="width"/>
+                        <field name="origin_x"/>
+                        <field name="origin_y"/>
+                        <field name="restore_saved_config"/>
+                    </group>
+                    <notebook>
+                        <page string="Components">
+                            <field name="component_ids" nolabel="1" colspan="4">
+                                <tree string="Label Component">
+                                    <field name="sequence"/>
+                                    <field name="name"/>
+                                    <field name="component_type"/>
+                                    <field name="origin_x"/>
+                                    <field name="origin_y"/>
+                                </tree>
+                                <form string="Label Component">
+                                    <group>
+                                        <group>
+                                            <field name="name"/>
+                                            <field name="sequence"/>
+                                        </group>
+                                        <group>
+                                            <field name="component_type"/>
+                                            <field name="repeat" attrs="{'invisible': [('component_type', '=', 'zpl2_raw')]}"/>
+                                        </group>
+                                        <group attrs="{'invisible': [('component_type', '=', 'zpl2_raw')]}">
+                                            <field name="origin_x"/>
+                                            <field name="origin_y"/>
+                                        </group>
+                                        <group>
+                                            <field name="graphic_image" attrs="{'invisible': [('component_type', '!=', 'graphic')]}"/>
+                                            <field name="sublabel_id" attrs="{'invisible': [('component_type', '!=', 'sublabel')]}"/>
+                                        </group>
+                                    </group>
+                                    <group attrs="{'invisible': [('component_type', 'in', ('rectangle', 'diagonal', 'circle'))]}" string="Data">
+                                        <field name="data" widget="ace" options="{'mode': 'python'}" nolabel="1"/>
+                                    </group>
+                                    <notebook colspan="4">
+                                        <page string="Format" attrs="{'invisible': [('component_type', 'in', ('sublabel', 'qr_code', 'zpl2_raw'))]}">
+                                            <group>
+                                                <field name="height"/>
+                                                <field name="width" attrs="{'invisible': [('component_type', 'not in', ('text', 'rectangle', 'diagonal', 'circle', 'graphic'))]}"/>
+                                                <field name="reverse_print"/>
+                                                <field name="orientation" attrs="{'invisible': [('component_type', 'in', ('rectangle', 'diagonal', 'circle'))]}"/>
+                                                <field name="font" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>
+                                                <field name="in_block" attrs="{'invisible': [('component_type', '!=', 'text')]}"/>
+                                                <field name="thickness" attrs="{'invisible': [('component_type', 'not in', ('rectangle', 'diagonal', 'circle'))]}"/>
+                                                <field name="color" attrs="{'invisible': [('component_type', 'not in', ('rectangle', 'diagonal', 'circle'))]}"/>
+                                                <field name="diagonal_orientation" attrs="{'invisible': [('component_type', '!=', 'diagonal')], 'required': [('component_type', '=', 'diagonal')]}"/>
+                                            </group>
+                                        </page>
+                                        <!-- Barcode specific arguments -->
+                                        <page string="Barcode Format" attrs="{'invisible': [('component_type', 'in', ('text', 'rectangle', 'diagonal', 'circle', 'sublabel', 'graphic', 'qr_code', 'zpl2_raw'))]}">
+                                            <group>
+                                                <field name="check_digits"/>
+                                                <field name="interpretation_line"/>
+                                                <field name="interpretation_line_above"/>
+                                                <field name="module_width"/>
+                                                <field name="bar_width_ratio"/>
+                                                <field name="security_level"/>
+                                                <field name="columns_count"/>
+                                                <field name="rows_count"/>
+                                                <field name="truncate"/>
+                                            </group>
+                                        </page>
+                                        <!-- 2D Barcode arguments -->
+                                        <page string="2D Barcode Arguments" attrs="{'invisible': [('component_type', '!=', 'qr_code')]}">
+                                            <group>
+                                                <field name="model"/>
+                                                <field name="magnification_factor"/>
+                                                <field name="error_correction"/>
+                                                <field name="mask_value"/>
+                                            </group>
+                                        </page>
+                                        <!-- Text block specific arguments -->
+                                        <page string="Text Block Format" attrs="{'invisible': ['|', ('component_type', '!=', 'text'), ('in_block', '=', False)]}">
+                                            <group>
+                                                <field name="block_width"/>
+                                                <field name="block_lines"/>
+                                                <field name="block_spaces"/>
+                                                <field name="block_justify"/>
+                                                <field name="block_left_margin"/>
+                                            </group>
+                                        </page>
+                                        <!-- Repeat specific arguments -->
+                                        <page string="Repeat" attrs="{'invisible': [('repeat', '=', False)]}">
+                                            <group>
+                                                <field name="repeat_offset"/>
+                                                <field name="repeat_count"/>
+                                                <field name="repeat_offset_x"/>
+                                                <field name="repeat_offset_y"/>
+                                            </group>
+                                        </page>
+                                    </notebook>
+                                </form>
+                            </field>
+                            <group string="Emulation" attrs="{'invisible':[('test_labelary_mode', '=', False)]}">
+                                <field name="labelary_image" widget="image" nolabel="1" force_save="1"/>
+                                <p class="oe_grey" colspan="4">
+                                    Note : It is an emulation from http://labelary.com/, the result on printer can be different.
+                                </p>
+                            </group>
+                        </page>
+                        <page string="Test Mode">
+                            <group>
+                                <group>
+                                    <field name="test_labelary_mode"/>
+                                </group>
+                            </group>
+                            <group>
+                                <group>
+                                    <field name="record_id" attrs="{'invisible':[('test_labelary_mode', '=', False)], 'required':[('test_labelary_mode', '=', True)]}"/>
+
+                                    <field name="labelary_dpmm" attrs="{'invisible':[('test_labelary_mode', '=', False)], 'required':[('test_labelary_mode', '=', True)]}"/>
+                                    <field name="labelary_width" attrs="{'invisible':[('test_labelary_mode', '=', False)], 'required':[('test_labelary_mode', '=', True)]}"/>
+                                    <field name="labelary_height" attrs="{'invisible':[('test_labelary_mode', '=', False)], 'required':[('test_labelary_mode', '=', True)]}"/>
+                                </group>
+                            </group>
+                            <group string="Extra">
+                                <field name="extra" nolabel="1" widget="ace" options="{'mode': 'python'}" attrs="{'invisible':[('test_labelary_mode', '=', False)]}"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="view_printing_label_zpl2_search" model="ir.ui.view">
+        <field name="model">printing.label.zpl2</field>
+        <field name="arch" type="xml">
+            <search string="ZPL II Label">
+                <field name="name"/>
+                <field name="model_id"/>
+                <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
+            </search>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="act_open_printing_label_zpl2_view">
+        <field name="name">ZPL II Labels</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">printing.label.zpl2</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_printing_label_zpl2_search"/>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_printing_label_zpl2_view_form">
+        <field name="act_window_id" ref="act_open_printing_label_zpl2_view"/>
+        <field name="sequence" eval="20"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_printing_label_zpl2_form"/>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_printing_label_zpl2_view_tree">
+        <field name="act_window_id" ref="act_open_printing_label_zpl2_view"/>
+        <field name="sequence" eval="10"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_printing_label_zpl2_tree"/>
+    </record>
+    <menuitem name="Labels"
+        id="label_menu" sequence="1"
+        parent="base.menu_administration"
+        groups="label_group_manager"
+        />
+    <menuitem id="menu_printing_label_zpl2" parent="label_menu" sequence="20" action="act_open_printing_label_zpl2_view"/>
+</odoo>

--- a/label_zpl2/wizard/__init__.py
+++ b/label_zpl2/wizard/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import wizard_import_zpl2

--- a/label_zpl2/wizard/wizard_import_zpl2.py
+++ b/label_zpl2/wizard/wizard_import_zpl2.py
@@ -1,0 +1,440 @@
+# Copyright (C) 2018 Florent Mirieu (<https://github.com/fmdl>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+import re
+import base64
+import binascii
+import io
+
+
+from PIL import Image, ImageOps
+from odoo import fields, models, _
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import zpl2
+except ImportError:
+    _logger.debug('Cannot `import zpl2`.')
+
+
+def _compute_arg(data, arg):
+    vals = {}
+    for i, d in enumerate(data.split(',')):
+        vals[arg[i]] = d
+    return vals
+
+
+def _field_origin(data):
+    if data[:2] == 'FO':
+        position = data[2:]
+        vals = _compute_arg(position, ['origin_x', 'origin_y'])
+        return vals
+    return {}
+
+
+def _font_format(data):
+    if data[:1] == 'A':
+        data = data.split(',')
+        vals = {}
+        if len(data[0]) > 1:
+            vals[zpl2.ARG_FONT] = data[0][1]
+        if len(data[0]) > 2:
+            vals[zpl2.ARG_ORIENTATION] = data[0][2]
+
+        if len(data) > 1:
+            vals[zpl2.ARG_HEIGHT] = data[1]
+        if len(data) > 2:
+            vals[zpl2.ARG_WIDTH] = data[2]
+        return vals
+    return {}
+
+
+def _default_font_format(data):
+    if data[:2] == 'CF':
+        args = [
+            zpl2.ARG_FONT,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_WIDTH,
+        ]
+        vals = _compute_arg(data[2:], args)
+        if vals.get(zpl2.ARG_HEIGHT, False) \
+                and not vals.get(zpl2.ARG_WIDTH, False):
+            vals.update({zpl2.ARG_WIDTH: vals.get(zpl2.ARG_HEIGHT)})
+        else:
+            vals.update({zpl2.ARG_HEIGHT: 10, zpl2.ARG_HEIGHT: 10})
+        return vals
+    return {}
+
+
+def _field_block(data):
+    if data[:2] == 'FB':
+        vals = {zpl2.ARG_IN_BLOCK: True}
+        args = [
+            zpl2.ARG_BLOCK_WIDTH,
+            zpl2.ARG_BLOCK_LINES,
+            zpl2.ARG_BLOCK_SPACES,
+            zpl2.ARG_BLOCK_JUSTIFY,
+            zpl2.ARG_BLOCK_LEFT_MARGIN,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _code11(data):
+    if data[:2] == 'B1':
+        vals = {'component_type': zpl2.BARCODE_CODE_11}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_CHECK_DIGITS,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _interleaved2of5(data):
+    if data[:2] == 'B2':
+        vals = {'component_type': zpl2.BARCODE_INTERLEAVED_2_OF_5}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+            zpl2.ARG_CHECK_DIGITS,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _code39(data):
+    if data[:2] == 'B3':
+        vals = {'component_type': zpl2.BARCODE_CODE_39}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_CHECK_DIGITS,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _code49(data):
+    if data[:2] == 'B4':
+        vals = {'component_type': zpl2.BARCODE_CODE_49}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_STARTING_MODE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _pdf417(data):
+    if data[:2] == 'B7':
+        vals = {'component_type': zpl2.BARCODE_PDF417}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_SECURITY_LEVEL,
+            zpl2.ARG_COLUMNS_COUNT,
+            zpl2.ARG_ROWS_COUNT,
+            zpl2.ARG_TRUNCATE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _ean8(data):
+    if data[:2] == 'B8':
+        vals = {'component_type': zpl2.BARCODE_EAN_8}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _upce(data):
+    if data[:2] == 'B9':
+        vals = {'component_type': zpl2.BARCODE_UPC_E}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+            zpl2.ARG_CHECK_DIGITS,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _code128(data):
+    if data[:2] == 'BC':
+        vals = {'component_type': zpl2.BARCODE_CODE_128}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+            zpl2.ARG_CHECK_DIGITS,
+            zpl2.ARG_MODE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _ean13(data):
+    if data[:2] == 'BE':
+        vals = {'component_type': zpl2.BARCODE_EAN_13}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_INTERPRETATION_LINE,
+            zpl2.ARG_INTERPRETATION_LINE_ABOVE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _qrcode(data):
+    if data[:2] == 'BQ':
+        vals = {'component_type': zpl2.BARCODE_QR_CODE}
+        args = [
+            zpl2.ARG_ORIENTATION,
+            zpl2.ARG_MODEL,
+            zpl2.ARG_MAGNIFICATION_FACTOR,
+            zpl2.ARG_ERROR_CORRECTION,
+            zpl2.ARG_MASK_VALUE,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _default_barcode_field(data):
+    if data[:2] == 'BY':
+        args = [
+            zpl2.ARG_MODULE_WIDTH,
+            zpl2.ARG_BAR_WIDTH_RATIO,
+            zpl2.ARG_HEIGHT,
+        ]
+        return _compute_arg(data[2:], args)
+    return {}
+
+
+def _field_reverse_print(data):
+    if data[:2] == 'FR':
+        return {zpl2.ARG_REVERSE_PRINT: True}
+    return {}
+
+
+def _graphic_box(data):
+    if data[:2] == 'GB':
+        vals = {'component_type': 'rectangle'}
+        args = [
+            zpl2.ARG_WIDTH,
+            zpl2.ARG_HEIGHT,
+            zpl2.ARG_THICKNESS,
+            zpl2.ARG_COLOR,
+            zpl2.ARG_ROUNDING,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _graphic_circle(data):
+    if data[:2] == 'GC':
+        vals = {'component_type': 'circle'}
+        args = [
+            zpl2.ARG_WIDTH,
+            zpl2.ARG_THICKNESS,
+            zpl2.ARG_COLOR,
+        ]
+        vals.update(_compute_arg(data[2:], args))
+        return vals
+    return {}
+
+
+def _graphic_field(data):
+    if data[:3] == 'GFA':
+        vals = {}
+        args = [
+            'compression',
+            'total_bytes',
+            'total_bytes',
+            'bytes_per_row',
+            'ascii_data',
+        ]
+        vals.update(_compute_arg(data[3:], args))
+
+        # Image
+        rawData = re.sub('[^A-F0-9]+', '', vals['ascii_data'])
+        rawData = binascii.unhexlify(rawData)
+
+        width = int(float(vals['bytes_per_row']) * 8)
+        height = int(float(vals['total_bytes']) / width) * 8
+
+        img = Image.frombytes(
+            '1', (width, height), rawData, 'raw').convert('L')
+        img = ImageOps.invert(img)
+
+        imgByteArr = io.BytesIO()
+        img.save(imgByteArr, format='PNG')
+        image = base64.b64encode(imgByteArr.getvalue())
+
+        return {
+            'component_type': 'graphic',
+            'graphic_image': image,
+            zpl2.ARG_WIDTH: width,
+            zpl2.ARG_HEIGHT: height,
+        }
+    return {}
+
+
+def _get_data(data):
+    if data[:2] == 'FD':
+        return {'data': '"%s"' % data[2:]}
+    return {}
+
+
+SUPPORTED_CODE = {
+    'FO': {'method': _field_origin},
+    'FD': {'method': _get_data},
+    'A': {'method': _font_format},
+    'FB': {'method': _field_block},
+    'B1': {'method': _code11},
+    'B2': {'method': _interleaved2of5},
+    'B3': {'method': _code39},
+    'B4': {'method': _code49},
+    'B7': {'method': _pdf417},
+    'B8': {'method': _ean8},
+    'B9': {'method': _upce},
+    'BC': {'method': _code128},
+    'BE': {'method': _ean13},
+    'BQ': {'method': _qrcode},
+    'BY': {
+        'method': _default_barcode_field,
+        'default': [
+            zpl2.BARCODE_CODE_11,
+            zpl2.BARCODE_INTERLEAVED_2_OF_5,
+            zpl2.BARCODE_CODE_39,
+            zpl2.BARCODE_CODE_49,
+            zpl2.BARCODE_PDF417,
+            zpl2.BARCODE_EAN_8,
+            zpl2.BARCODE_UPC_E,
+            zpl2.BARCODE_CODE_128,
+            zpl2.BARCODE_EAN_13,
+            zpl2.BARCODE_QR_CODE,
+        ],
+    },
+    'CF': {'method': _default_font_format, 'default': ['text']},
+    'FR': {'method': _field_reverse_print},
+    'GB': {'method': _graphic_box},
+    'GC': {'method': _graphic_circle},
+    'GFA': {'method': _graphic_field},
+}
+
+
+class WizardImportZPl2(models.TransientModel):
+    _name = 'wizard.import.zpl2'
+    _description = 'Import ZPL2'
+
+    label_id = fields.Many2one(
+        comodel_name='printing.label.zpl2', string='Label',
+        required=True, readonly=True,)
+    data = fields.Text(
+        required=True, help='Printer used to print the labels.')
+    delete_component = fields.Boolean(
+        string='Delete existing components', default=False)
+
+    def _start_sequence(self):
+        sequences = self.mapped('label_id.component_ids.sequence')
+        if sequences:
+            return max(sequences) + 1
+        return 0
+
+    def import_zpl2(self):
+        Zpl2Component = self.env['printing.label.zpl2.component']
+
+        if self.delete_component:
+            self.mapped('label_id.component_ids').unlink()
+
+        Model = self.env['printing.label.zpl2.component']
+        self.model_fields = Model.fields_get()
+        sequence = self._start_sequence()
+        default = {}
+
+        for i, line in enumerate(self.data.split('\n')):
+            vals = {}
+
+            args = line.split('^')
+            for arg in args:
+                for key, code in SUPPORTED_CODE.items():
+                    component_arg = code['method'](arg)
+                    if component_arg:
+                        if code.get('default', False):
+                            for deft in code.get('default'):
+                                default.update({deft: component_arg})
+                        else:
+                            vals.update(component_arg)
+                        break
+
+            if vals:
+                if 'component_type' not in vals.keys():
+                    vals.update({'component_type': 'text'})
+
+                if vals['component_type'] in default.keys():
+                    vals.update(default[vals['component_type']])
+
+                vals = self._update_vals(vals)
+
+                seq = sequence + i * 10
+                vals.update({
+                    'name': _('Import %s') % seq,
+                    'sequence': seq,
+                    'label_id': self.label_id.id,
+                })
+                Zpl2Component.create(vals)
+
+    def _update_vals(self, vals):
+        if 'orientation' in vals.keys() and vals['orientation'] == '':
+            vals['orientation'] = 'N'
+
+        # Field
+        component = {}
+        for field, value in vals.items():
+            if field in self.model_fields.keys():
+                field_type = self.model_fields[field].get('type', False)
+                if field_type == 'boolean':
+                    if not value or value == zpl2.BOOL_NO:
+                        value = False
+                    else:
+                        value = True
+                if field_type in ('integer', 'float'):
+                    value = float(value)
+                if field == 'model':
+                    value = int(float(value))
+                component.update({field: value})
+        return component

--- a/label_zpl2/wizard/wizard_import_zpl2.xml
+++ b/label_zpl2/wizard/wizard_import_zpl2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_wizard_import_zpl2_form" model="ir.ui.view">
+        <field name="name">wizard.import.zpl2.form</field>
+        <field name="model">wizard.import.zpl2</field>
+        <field name="arch" type="xml">
+            <form string="Print Label">
+                <group>
+                    <group>
+                        <field name="label_id"/>
+                        <field name="delete_component"/>
+                    </group>
+                </group>
+                <group string="ZPL2">
+                    <field name="data" widget="ace" nolabel="1"/>
+                </group>
+                <footer>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                    <button string="Import" type="object" name="import_zpl2" class="btn-primary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
I have detected that `printer_zpl2` depends on `base_report_to_printer` but I think it may not be the best options, because you could require zpl2 but not use the module of printers.

This PR splits the module in two. The first is `label_zpl2`, that creates the models and allows to render the labels. The second is `printer_zpl2` that will inherit from the first.