### PR TITLE
[ADD] remote_report_to_printer

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+server-tools

--- a/remote_report_to_printer/README.rst
+++ b/remote_report_to_printer/README.rst
@@ -22,7 +22,7 @@ Also, this option can be selected as a user default option for printer.
 Usage
 =====
 
- * In *Settings > User & Companies > Remotes* configure the remotes printers by usage
+ * In *Settings > Remotes* configure the remotes printers by usage
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/remote_report_to_printer/README.rst
+++ b/remote_report_to_printer/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+Report To Printer
+=================
+
+This module allows users to send reports to a printer using remote's configuration.
+
+A *remote* is an external entity that access odoo. For example, computers, mobiles,
+servers... We will identify *remotes* by its name or ip. On some environments,
+we want to configure the printers by remote, because users may change their
+work place.
+
+It adds an optional behaviour on reports to send it directly to a printer.
+
+* `Use remote's configuration` use the remote's behaviour
+
+Also, this option can be selected as a user default option for printer.
+
+Usage
+=====
+
+ * In *Settings > User & Companies > Remotes* configure the remotes printers by usage
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/144/11.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/report-print-send/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Enric Tobella <etobella@creublanca.es>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/remote_report_to_printer/__init__.py
+++ b/remote_report_to_printer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/remote_report_to_printer/__manifest__.py
+++ b/remote_report_to_printer/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': "Report to printer on remotes",
+    'version': '11.0.2.1.0',
+    'category': 'Generic Modules/Base',
+    'author': "Creu Blanca, Odoo Community Association (OCA)",
+    'website': 'http://www.agilebg.com',
+    'license': 'AGPL-3',
+    "depends": ['base_remote', 'base_report_to_printer'],
+    'data': [
+        'data/printing_data.xml',
+        'security/ir.model.access.csv',
+        'views/res_remote_views.xml',
+        'views/res_remote_printer_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/remote_report_to_printer/data/printing_data.xml
+++ b/remote_report_to_printer/data/printing_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+
+    <record model="printing.action" id="printing_action_remote">
+        <field name="name">Use Remote Defaults</field>
+        <field name="action_type">remote_default</field>
+    </record>
+
+</odoo>

--- a/remote_report_to_printer/models/__init__.py
+++ b/remote_report_to_printer/models/__init__.py
@@ -1,0 +1,4 @@
+from . import ir_actions_report
+from . import res_remote
+from . import res_remote_printer
+from . import printing_action

--- a/remote_report_to_printer/models/ir_actions_report.py
+++ b/remote_report_to_printer/models/ir_actions_report.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrActionsReport(models.Model):
+    _inherit = 'ir.actions.report'
+
+    @api.multi
+    def _get_user_default_print_behaviour(self):
+        res = super()._get_user_default_print_behaviour()
+        if res.get('action', 'unknown') == 'remote_default':
+            res.update(self.remote.get_printer_behaviour())
+        return res
+
+    @api.multi
+    def _get_report_default_print_behaviour(self):
+        res = super()._get_report_default_print_behaviour()
+        if res.get('action', 'unknown') == 'remote_default':
+            res.update(self.remote.get_printer_behaviour())
+        return res

--- a/remote_report_to_printer/models/printing_action.py
+++ b/remote_report_to_printer/models/printing_action.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class PrintingAction(models.Model):
+    _inherit = 'printing.action'
+
+    @api.model
+    def _available_action_types(self):
+        res = super()._available_action_types()
+        res.append(('remote_default', "Use remote's default"))
+        return res
+
+    action_type = fields.Selection(
+        selection=_available_action_types,
+    )

--- a/remote_report_to_printer/models/res_remote.py
+++ b/remote_report_to_printer/models/res_remote.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class ResRemote(models.Model):
+    _inherit = 'res.remote'
+
+    remote_printer_ids = fields.One2many(
+        'res.remote.printer',
+        inverse_name='remote_id',
+    )
+
+    @api.multi
+    def get_printer_behaviour(self):
+        self.ensure_one()
+        printer_usage = self.env.context.get('printer_usage', 'standard')
+        printers = self.remote.remote_printer_ids.filtered(
+            lambda r: r.printer_usage == printer_usage
+        ).sorted(key='is_default', reverse=True)
+        if printers:
+            printer = printers[0]
+            return {
+                'action': 'server',
+                'printer': printer.printer_id,
+                'tray': printer.printer_tray_id.system_name
+            }
+        return {'action': 'client'}

--- a/remote_report_to_printer/models/res_remote_printer.py
+++ b/remote_report_to_printer/models/res_remote_printer.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResRemotePrinter(models.Model):
+    _name = 'res.remote.printer'
+
+    remote_id = fields.Many2one(
+        'res.remote',
+        ondelete='cascade',
+        readonly=True,
+    )
+    printer_id = fields.Many2one(
+        'printing.printer',
+        ondelete='cascade',
+    )
+    printer_tray_id = fields.Many2one(
+        'printing.tray',
+        ondelete='cascade',
+        domain="[('printer_id', '=', printer_id)]",
+    )
+    is_default = fields.Boolean(default=False)
+    printer_usage = fields.Selection([
+        ('standard', 'Standard')
+    ], default='standard')
+
+    _sql_constraints = [
+        ('unique_printer_remote_usage',
+         'unique(remote_id,printer_id,printer_usage)',
+         'A Remote cannot have the same printer for the same usage')
+    ]
+
+    @api.onchange('printer_id')
+    def _onchange_printing_printer_id(self):
+        """ Reset the tray when the printer is changed """
+        self.printer_tray_id = False
+
+    @api.multi
+    @api.constrains('remote_id', 'printer_usage', 'is_default')
+    def _check_remote_usage(self):
+        for rec in self.filtered(lambda r: r.is_default):
+            if rec.remote_id.remote_printer_ids.filtered(
+                lambda r: r != rec and r.is_default
+                and r.printer_usage == rec.printer_usage
+            ):
+                raise ValidationError(_('Only one default printer is allowed'))

--- a/remote_report_to_printer/security/ir.model.access.csv
+++ b/remote_report_to_printer/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_remote,access_remote_printer,model_res_remote_printer,base.group_user,1,0,0,0
+manage_remote,manage_remote_printer,model_res_remote_printer,base.group_system,1,1,0,0

--- a/remote_report_to_printer/tests/__init__.py
+++ b/remote_report_to_printer/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_remote_printer
+from . import test_printer

--- a/remote_report_to_printer/tests/test_printer.py
+++ b/remote_report_to_printer/tests/test_printer.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests.common import TransactionCase
+from mock import patch
+
+
+class TestRemotePrinter(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        name = 'testing_remote_server'
+        self.remote = self.env['res.remote'].search([('name', '=', name)])
+        if not self.remote:
+            self.remote = self.env['res.remote'].create({
+                'name': name,
+                'ip': '127.0.0.1',
+            })
+        self.server = self.env['printing.server'].create({
+            'name': 'Server',
+            'address': 'localhost',
+            'port': 631,
+        })
+        self.printer_1 = self.env['printing.printer'].create({
+            'name': 'Printer 1',
+            'system_name': 'P1',
+            'server_id': self.server.id,
+        })
+        self.remote_printer = self.env['res.remote.printer'].create({
+            'remote_id': self.remote.id,
+            'printer_id': self.printer_1.id,
+            'is_default': True,
+        })
+        self.Model = self.env['ir.actions.report']
+        self.report = self.env['ir.actions.report'].search([], limit=1)
+
+    def test_behaviour_user_remote_values(self):
+        report = self.Model.search([], limit=1)
+        self.env.user.printing_action = 'remote_default'
+        with patch(
+            'odoo.addons.base_remote.models.base.Base.remote', new=self.remote
+        ):
+            behaviour = report.behaviour()
+        self.assertEqual(behaviour, {
+            'action': 'client',
+            'printer': self.printer_1,
+            'tray': False,
+        })
+
+    def test_behaviour_report_values(self):
+        report = self.Model.search([], limit=1)
+        self.env.user.printing_action = 'client'
+        report.property_printing_action_id = self.browse_ref(
+            'remote_report_to_printer.printing_action_remote'
+        )
+        with patch(
+            'odoo.addons.base_remote.models.base.Base.remote', new=self.remote
+        ):
+            behaviour = report.behaviour()
+        self.assertDictEqual(behaviour, {
+            'action': 'server',
+            'printer': self.printer_1,
+            'tray': False,
+        })
+
+    def test_behaviour_user_action(self):
+        report = self.Model.search([], limit=1)
+        self.env.user.printing_action = 'remote_default'
+        report.property_printing_action_id = self.browse_ref(
+            'base_report_to_printer.printing_action_3'
+        )
+        with patch(
+            'odoo.addons.base_remote.models.base.Base.remote', new=self.remote
+        ):
+            behaviour = report.behaviour()
+        self.assertEqual(behaviour, {
+            'action': 'server',
+            'printer': self.printer_1,
+            'tray': False,
+        })
+
+    def test_behaviour_default_action(self):
+        report = self.Model.search([], limit=1)
+        self.env.user.printing_action = 'client'
+        with patch(
+            'odoo.addons.base_remote.models.base.Base.remote', new=self.remote
+        ):
+            behaviour = report.behaviour()
+        self.assertEqual(behaviour, {
+            'action': 'client',
+            'printer': self.env['printing.printer'],
+            'tray': False,
+        })
+
+    def test_behaviour_no_printers(self):
+        self.remote_printer.unlink()
+        report = self.Model.search([], limit=1)
+        self.env.user.printing_action = 'remote_default'
+        report.property_printing_action_id = self.browse_ref(
+            'base_report_to_printer.printing_action_3'
+        )
+        with patch(
+            'odoo.addons.base_remote.models.base.Base.remote',
+            new=self.remote
+        ):
+            behaviour = report.behaviour()
+        self.assertEqual(behaviour['action'], 'client')

--- a/remote_report_to_printer/tests/test_remote_printer.py
+++ b/remote_report_to_printer/tests/test_remote_printer.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2018 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+
+class TestRemotePrinter(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        name = 'testing_remote_server'
+        self.remote = self.env['res.remote'].search([('name', '=', name)])
+        if not self.remote:
+            self.remote = self.env['res.remote'].create({
+                'name': name,
+                'ip': '127.0.0.1',
+            })
+        self.server = self.env['printing.server'].create({
+            'name': 'Server',
+            'address': 'localhost',
+            'port': 631,
+        })
+        self.printer_1 = self.env['printing.printer'].create({
+            'name': 'Printer 1',
+            'system_name': 'P1',
+            'server_id': self.server.id,
+        })
+        self.printer_2 = self.env['printing.printer'].create({
+            'name': 'Printer 2',
+            'system_name': 'P2',
+            'server_id': self.server.id,
+        })
+        self.tray_1 = self.env['printing.tray'].create({
+            'name': 'Tray',
+            'system_name': 'P2',
+            'printer_id': self.printer_1.id,
+        })
+
+    def test_constrain(self):
+        self.env['res.remote.printer'].create({
+            'remote_id': self.remote.id,
+            'printer_id': self.printer_1.id,
+            'is_default': True,
+        })
+        with self.assertRaises(ValidationError):
+            self.env['res.remote.printer'].create({
+                'remote_id': self.remote.id,
+                'printer_id': self.printer_2.id,
+                'is_default': True,
+            })
+
+    def test_onchange_printer(self):
+        remote_printer = self.env['res.remote.printer'].create({
+            'remote_id': self.remote.id,
+            'printer_id': self.printer_1.id,
+            'printer_tray_id': self.tray_1.id,
+        })
+        self.assertTrue(remote_printer.printer_tray_id)
+        remote_printer.printer_id = self.printer_2
+        remote_printer._onchange_printing_printer_id()
+        self.assertFalse(remote_printer.printer_tray_id)

--- a/remote_report_to_printer/views/res_remote_printer_views.xml
+++ b/remote_report_to_printer/views/res_remote_printer_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_remote_printer_form" model="ir.ui.view">
+        <field name="name">res.remote.printer.form</field>
+        <field name="model">res.remote.printer</field>
+        <field name="arch" type="xml">
+            <form string="Remote Printer">
+                <sheet>
+                    <group>
+                        <field name="printer_id"/>
+                        <field name="printer_tray_id"/>
+                        <field name="printer_usage"/>
+                        <field name="is_default"/>
+                        <field name="remote_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="res_remote_printer_tree" model="ir.ui.view">
+        <field name="name">res.remote.printer.tree</field>
+        <field name="model">res.remote.printer</field>
+        <field name="arch" type="xml">
+            <tree string="Remote Printers" editable="bottom">
+                <field name="printer_id"/>
+                <field name="printer_tray_id"/>
+                <field name="is_default"/>
+                <field name="printer_usage"/>
+                <field name="remote_id" invisible="1"/>
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/remote_report_to_printer/views/res_remote_views.xml
+++ b/remote_report_to_printer/views/res_remote_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_remote_form" model="ir.ui.view">
+        <field name="name">res.remote.form</field>
+        <field name="model">res.remote</field>
+        <field name="inherit_id" ref="base_remote.res_remote_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page name="printers" string="Printers">
+                    <field name="remote_printer_ids"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Report To Printer
=================

This module allows users to send reports to a printer using remote's configuration.

It adds an optional behaviour on reports to send it directly to a printer.

* `Use remote's configuration` use the remote's behaviour

Also, this option can be selected as a user default option for printer.

Usage
=====

 * In *Settings > User & Companies > Remotes* configure the remotes printers by usage