### PR TITLE
[FIX][base_report_to_printer] - print documents with ir.actions.repor…

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': "Report to printer",
-    'version': '11.0.2.2.0',
+    'version': '11.0.2.3.0',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
               " LasLabs, Camptocamp, Odoo Community Association (OCA)",

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -129,6 +129,13 @@ class IrActionsReport(models.Model):
             return True
         return False
 
+    @api.noguess
+    def report_action(self, docids, data=None, config=True):
+        res = super().report_action(docids, data=data, config=config)
+        if not res.get('id'):
+            res['id'] = self.id
+        return res
+
     def render_qweb_pdf(self, docids, data=None):
         """ Generate a PDF and returns it.
 


### PR DESCRIPTION
### Impacted Versions
11.0

### Steps to Reproduce

1. Configure a CUPS server in Odoo.

2. Search the active printers

3. Configure the report action (send_to_printer) and select the printer.

4. Print the report.

### Current Behaviour
The module returns an error ( "Error when sending the document to the printer").
This error is launched because the module when a report is sended to the printer from the method "render_qweb_pdf", self is an instance of ir.actions.report without any object and on the super call Odoo try to instance the active model with self.active_model and returns a traceback with a KeyError.

![captura realizada el 2018-06-21 09 29 48](https://user-images.githubusercontent.com/16998467/41726105-05ded2bc-7537-11e8-9914-0cd146c54fe9.png)


###  Desired Behaviour
The report must be sendend to the printer successfuly.

### Extra
I attach a video with the behaviour.
https://youtu.be/3GU1Q-sjtl8

@etobella could you help me reviewing this PR please? :pray: 
Regards
