### PR TITLE
[9.0][IMP] Change version to allow install in Ubuntu 16.04+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycups==1.9.66
+pycups>=1.9.68
 PyPDF2==1.18
 requests
 zpl2


### PR DESCRIPTION
The version 1.9.66 is very old, and is not possible install in Ubuntu 16.04. Presumably, in future versions either.