### PR TITLE
[8.0][IMP] Change version to allow install in Ubuntu 16.04+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pycups==1.9.66
+pycups>=1.9.68
 PyPDF2==1.18
 requests


### PR DESCRIPTION
Same problem that https://github.com/OCA/report-print-send/pull/157/files but version 8.0