### PR TITLE
[11.0][remote_report_to_printer] add permissions to write and delete to base.group_system

### DIFF
--- a/remote_report_to_printer/__manifest__.py
+++ b/remote_report_to_printer/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': "Report to printer on remotes",
-    'version': '11.0.2.1.0',
+    'version': '11.0.2.1.1',
     'category': 'Generic Modules/Base',
     'author': "Creu Blanca, Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',

--- a/remote_report_to_printer/security/ir.model.access.csv
+++ b/remote_report_to_printer/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_remote,access_remote_printer,model_res_remote_printer,base.group_user,1,0,0,0
-manage_remote,manage_remote_printer,model_res_remote_printer,base.group_system,1,1,0,0
+manage_remote,manage_remote_printer,model_res_remote_printer,base.group_system,1,1,1,1


### PR DESCRIPTION
Otherwise only the admin user was able to edit / delete remote printers.