### PR TITLE
[FIX] printer_zpl2: QR as automatic input

### DIFF
--- a/printer_zpl2/__manifest__.py
+++ b/printer_zpl2/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Printer ZPL II',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Printer',
     'author': 'SYLEAM, Apertoso NV, Odoo Community Association (OCA)',
     'website': 'http://www.syleam.fr/',

--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -191,7 +191,7 @@ class PrintingLabelZpl2(models.Model):
             else:
                 if component.component_type == zpl2.BARCODE_QR_CODE:
                     # Adding Control Arguments to QRCode data Label
-                    data = 'MM,A{}'.format(data)
+                    data = '{}A,{}'.format(component.error_correction, data)
 
                 barcode_arguments = dict([
                     (field_name, component[field_name])

--- a/printer_zpl2/tests/test_printing_label_zpl2.py
+++ b/printer_zpl2/tests/test_printing_label_zpl2.py
@@ -1002,7 +1002,7 @@ class TestPrintingLabelZpl2(TransactionCase):
             # Component format
             '^BQN,2,1,Q,7'
             # Component contents
-            '^FDMM,A{contents}'
+            '^FDQA,{contents}'
             # Component end
             '^FS\n'
             # Recall last saved parameters


### PR DESCRIPTION
Without this PR, QR can only be alphanumeric (upper case) and now, it will detect automatically what to do. For example, now, you can insert a json inside a QR.