### PR TITLE
[FIX] base_report_to_printer: Migrate noupdate record

### DIFF
--- a/base_report_to_printer/migrations/9.0.2.0.0/post-10-create_server_record.py
+++ b/base_report_to_printer/migrations/9.0.2.0.0/post-10-create_server_record.py
@@ -18,3 +18,13 @@ def migrate(cr, v):
             'port': config.get('cups_port', 631),
             'printer_ids': [(6, 0, env['printing.printer'].search([]).ids)],
         })
+        # Update the noupdate=1 cron if modified fields weren't touched
+        cron = env.ref("base_report_to_printer.ir_cron_update_printers")
+        if (
+            cron.model == "printing.printer" and
+            cron.function == "update_printers_status"
+        ):
+            cron.write({
+                "function": "action_update_jobs",
+                "model": "printing.server",
+            })


### PR DESCRIPTION
In version 9.0.2.0.0, added in https://github.com/OCA/report-print-send/pull/60, the cron was modified. However, since it is a noupdate=1 record, preinstalled instances started failing there.

This fixes it.

@Tecnativa TT18838