### PR TITLE
[10.0][ADD] Report action defined per language

### DIFF
--- a/base_report_to_printer/models/ir_actions_report_xml.py
+++ b/base_report_to_printer/models/ir_actions_report_xml.py
@@ -83,12 +83,12 @@ class IrActionsReportXml(models.Model):
             if report.printing_printer_id:
                 printer = report.printing_printer_id
 
-            # Retrieve report-user specific values
+            # Retrieve report-user/language specific values
             print_action = printing_act_obj.search(
                 [('report_id', '=', report.id),
-                 ('user_id', '=', self.env.uid),
-                 ('action', '!=', 'user_default')],
-                limit=1)
+                 '|', ('user_id', '=', self.env.uid),
+                 ('language_id.code', '=', self.env.lang),
+                 ('action', '!=', 'user_default')])
             if print_action:
                 user_action = print_action.behaviour()
                 action = user_action['action']

--- a/base_report_to_printer/models/printing_report_xml_action.py
+++ b/base_report_to_printer/models/printing_report_xml_action.py
@@ -6,7 +6,8 @@
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 
 
 class PrintingReportXmlAction(models.Model):
@@ -19,8 +20,8 @@ class PrintingReportXmlAction(models.Model):
                                 ondelete='cascade')
     user_id = fields.Many2one(comodel_name='res.users',
                               string='User',
-                              required=True,
                               ondelete='cascade')
+    language_id = fields.Many2one('res.lang', 'Language')
     action = fields.Selection(
         selection=lambda s: s.env['printing.action']._available_action_types(),
         required=True,
@@ -28,11 +29,50 @@ class PrintingReportXmlAction(models.Model):
     printer_id = fields.Many2one(comodel_name='printing.printer',
                                  string='Printer')
 
+    _sql_constraints = [(
+        'unique_configuration', 'unique(report_id,user_id,language_id)',
+        'There is already an action defined for this user/language.'
+    )]
+
+    @api.constrains('user_id', 'language_id')
+    def check_action(self):
+        for action in self:
+            if not action.user_id and not action.language_id:
+                raise UserError(_(
+                    "You should set a user or a language for which this action "
+                    "applies to."))
+
     @api.multi
     def behaviour(self):
-        if not self:
+        action = self
+        if len(action) > 1:
+            action = self.select_action()
+        if not action:
             return {}
         return {
-            'action': self.action,
-            'printer': self.printer_id,
+            'action': action.action,
+            'printer': action.printer_id,
         }
+
+    @api.multi
+    def select_action(self):
+        """
+        Returns the action that makes the most sense for the print depending
+        on the context (user and language).
+        :return: One record of printing.report.xml.action
+        """
+        action = self
+        if len(self) > 1:
+            # Find the most relevant action : user first, language second
+            user_action = self.filtered(lambda a: a.user_id == self.env.user)
+            if user_action:
+                if len(user_action) == 1:
+                    action = user_action
+                else:
+                    user_language_action = user_action.filtered(
+                        lambda a: a.language_id.code == self.env.lang)
+                    if user_language_action:
+                        action = user_language_action
+            else:
+                action = self.filtered(lambda a: a.language_id.code == self.env.lang)
+        return action

--- a/base_report_to_printer/models/report.py
+++ b/base_report_to_printer/models/report.py
@@ -13,7 +13,8 @@ class Report(models.Model):
         """ Print a document, do not return the document file """
         document = self.with_context(must_skip_send_to_printer=True).get_pdf(
             record_ids, report_name, html=html, data=data)
-        report = self._get_report_from_name(report_name)
+        # Preserve language context for selecting options depending on the language
+        report = self._get_report_from_name(report_name).with_context(self.env.context)
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
         if not printer:

--- a/base_report_to_printer/views/ir_actions_report_xml_view.xml
+++ b/base_report_to_printer/views/ir_actions_report_xml_view.xml
@@ -13,7 +13,7 @@
             <field name="report_copies"/>
             <field name="printing_printer_id"/>
           </group>
-          <separator string="Specific actions per user"/>
+          <separator string="Specific actions per user/language"/>
           <field name="printing_action_ids"/>
         </page>
       </xpath>

--- a/base_report_to_printer/views/printing_report_view.xml
+++ b/base_report_to_printer/views/printing_report_view.xml
@@ -8,6 +8,7 @@
       <form string="Report Printing Actions">
         <group col="2">
             <field name="user_id"/>
+            <field name="language_id"/>
             <field name="action"/>
             <field name="printer_id" select="1"/>
         </group>
@@ -20,6 +21,7 @@
     <field name="arch" type="xml">
       <tree string="Report Printing Actions">
         <field name="user_id"/>
+        <field name="language_id"/>
         <field name="action" />
         <field name="printer_id" />
       </tree>


### PR DESCRIPTION
This enables to change the print configuration depending on the language. It is useful for printing documents differently depending on the language of the partner for instance.