### PR TITLE
[12.0][ADD] Report action defined per language

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -7,11 +7,11 @@
 
 {
     'name': "Report to printer",
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Generic Modules/Base',
     'author': "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
               " LasLabs, Camptocamp, Odoo Community Association (OCA),"
-              " Open for Small Business Ltd",
+              " Open for Small Business Ltd, Compassion Switzerland",
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',
     "depends": ['web'],

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -85,12 +85,12 @@ class IrActionsReport(models.Model):
         result = self._get_user_default_print_behaviour()
         result.update(self._get_report_default_print_behaviour())
 
-        # Retrieve report-user specific values
+        # Retrieve report-user/language specific values
         print_action = printing_act_obj.search([
             ('report_id', '=', self.id),
-            ('user_id', '=', self.env.uid),
-            ('action', '!=', 'user_default'),
-        ], limit=1)
+            '|', ('user_id', '=', self.env.uid),
+            ('language_id.code', '=', self.env.lang),
+            ('action', '!=', 'user_default')])
         if print_action:
             # For some reason design takes report defaults over
             # False action entries so we must allow for that here

--- a/base_report_to_printer/models/printing_report_xml_action.py
+++ b/base_report_to_printer/models/printing_report_xml_action.py
@@ -5,7 +5,8 @@
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 
 
 class PrintingReportXmlAction(models.Model):
@@ -18,8 +19,8 @@ class PrintingReportXmlAction(models.Model):
                                 ondelete='cascade')
     user_id = fields.Many2one(comodel_name='res.users',
                               string='User',
-                              required=True,
                               ondelete='cascade')
+    language_id = fields.Many2one('res.lang', 'Language')
     action = fields.Selection(
         selection=lambda s: s.env['printing.action']._available_action_types(),
         required=True,
@@ -33,6 +34,19 @@ class PrintingReportXmlAction(models.Model):
         domain="[('printer_id', '=', printer_id)]",
     )
 
+    _sql_constraints = [(
+        'unique_configuration', 'unique(report_id,user_id,language_id)',
+        'There is already an action defined for this user/language.'
+    )]
+
+    @api.constrains('user_id', 'language_id')
+    def check_action(self):
+        for action in self:
+            if not action.user_id and not action.language_id:
+                raise UserError(_(
+                    "You should set a user or a language for which this action "
+                    "applies to."))
+
     @api.onchange('printer_id')
     def onchange_printer_id(self):
         """ Reset the tray when the printer is changed """
@@ -40,10 +54,36 @@ class PrintingReportXmlAction(models.Model):
 
     @api.multi
     def behaviour(self):
-        if not self:
+        action = self
+        if len(action) > 1:
+            action = self.select_action()
+        if not action:
             return {}
         return {
-            'action': self.action,
-            'printer': self.printer_id,
-            'tray': self.printer_tray_id.system_name
+            'action': action.action,
+            'printer': action.printer_id,
+            'tray': action.printer_tray_id.system_name
         }
+
+    @api.multi
+    def select_action(self):
+        """
+        Returns the action that makes the most sense for the print depending
+        on the context (user and language).
+        :return: One record of printing.report.xml.action
+        """
+        action = self
+        if len(self) > 1:
+            # Find the most relevant action : user first, language second
+            user_action = self.filtered(lambda a: a.user_id == self.env.user)
+            if user_action:
+                if len(user_action) == 1:
+                    action = user_action
+                else:
+                    user_language_action = user_action.filtered(
+                        lambda a: a.language_id.code == self.env.lang)
+                    if user_language_action:
+                        action = user_language_action
+            else:
+                action = self.filtered(lambda a: a.language_id.code == self.env.lang)
+        return action

--- a/base_report_to_printer/views/ir_actions_report.xml
+++ b/base_report_to_printer/views/ir_actions_report.xml
@@ -14,7 +14,7 @@
                         <field name="printer_tray_id"/>
                     </group>
 
-                    <separator string="Specific actions per user"/>
+                    <separator string="Specific actions per user/language"/>
                     <field name="printing_action_ids"/>
                 </page>
             </xpath>

--- a/base_report_to_printer/views/printing_report.xml
+++ b/base_report_to_printer/views/printing_report.xml
@@ -8,6 +8,7 @@
             <form string="Report Printing Actions">
                 <group col="2">
                     <field name="user_id"/>
+                    <field name="language_id"/>
                     <field name="action"/>
                     <field name="printer_id" select="1"/>
                     <field name="printer_tray_id"/>
@@ -22,6 +23,7 @@
         <field name="arch" type="xml">
             <tree string="Report Printing Actions">
                 <field name="user_id"/>
+                <field name="language_id"/>
                 <field name="action"/>
                 <field name="printer_id"/>
                 <field name="printer_tray_id"/>


### PR DESCRIPTION
This enables to change the print configuration depending on the language. It is useful for printing documents differently depending on the language of the partner for instance. It will select the action depending on the language set in context.