### PR TITLE
[9.0][FIX] base_report_to_printer: Fix api.v8 get_pdf signature

### DIFF
--- a/base_report_to_printer/models/report.py
+++ b/base_report_to_printer/models/report.py
@@ -37,29 +37,21 @@ class Report(models.Model):
             return True
         return False
 
-    @api.v7
-    def get_pdf(self, cr, uid, ids, report_name, html=None,
-                data=None, context=None):
+    @api.model
+    def get_pdf(self, docids, report_name, html=None, data=None):
         """ Generate a PDF and returns it.
 
         If the action configured on the report is server, it prints the
         generated document as well.
         """
-        document = super(Report, self).get_pdf(cr, uid, ids, report_name,
-                                               html=html, data=data,
-                                               context=context)
-        report = self._get_report_from_name(cr, uid, report_name)
+        report = self._get_report_from_name(report_name)
+        docs = self.env[report.model].browse(docids)
+        document = super(Report, self).get_pdf(
+            docs, report_name, html=html, data=data
+        )
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
-        can_print_report = self._can_print_report(cr, uid, ids,
-                                                  behaviour, printer, document,
-                                                  context=context)
+        can_print_report = self._can_print_report(behaviour, printer, document)
         if can_print_report:
             printer.print_document(report, document, report.report_type)
         return document
-
-    @api.v8
-    def get_pdf(self, docs, report_name, html=None, data=None):
-        return self._model.get_pdf(self._cr, self._uid,
-                                   docs.ids, report_name,
-                                   html=html, data=data, context=self._context)

--- a/base_report_to_printer/models/report.py
+++ b/base_report_to_printer/models/report.py
@@ -11,9 +11,11 @@ class Report(models.Model):
     @api.model
     def print_document(self, record_ids, report_name, html=None, data=None):
         """ Print a document, do not return the document file """
-        document = self.with_context(must_skip_send_to_printer=True).get_pdf(
-            record_ids, report_name, html=html, data=data)
         report = self._get_report_from_name(report_name)
+        records = self.env[report.model].browse(record_ids)
+        document = self.with_context(must_skip_send_to_printer=True).get_pdf(
+            records, report_name, html=html, data=data,
+        )
         behaviour = report.behaviour()[report.id]
         printer = behaviour['printer']
         if not printer:
@@ -57,7 +59,7 @@ class Report(models.Model):
         return document
 
     @api.v8
-    def get_pdf(self, docids, report_name, html=None, data=None):
+    def get_pdf(self, docs, report_name, html=None, data=None):
         return self._model.get_pdf(self._cr, self._uid,
-                                   docids, report_name,
+                                   docs.ids, report_name,
                                    html=html, data=data, context=self._context)


### PR DESCRIPTION
I'm a bit confused with the change done on #77 for api.v8 `get_pdf`: https://github.com/OCA/report-print-send/pull/77/files#diff-0729f9ddc4d839c5661dad89db3bb9b5R59-R62

On OCA/OCB as well as on odoo/odoo, this method expects a recordset:
 - https://github.com/OCA/OCB/blob/9.0/addons/report/models/report.py#L272-L275
 - https://github.com/odoo/odoo/blob/9.0/addons/report/models/report.py#L272-L275

I guess it did work as long as no other module redefines this function, but then it's broken if one uses other modules as it the case with: https://github.com/OCA/l10n-switzerland/blob/9.0/l10n_ch_payment_slip/report/payment_slip_from_invoice.py#L72-L77

ping @sylvain-garancher @yvaucher @guewen 
