### PR TITLE
[12.0][ADD] print_datamatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - python-yaml
       - cups
       - libcups2-dev
+      - libdmtx0a
 
 env:
   global:

--- a/report_barcode_datamatrix/__init__.py
+++ b/report_barcode_datamatrix/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/report_barcode_datamatrix/__manifest__.py
+++ b/report_barcode_datamatrix/__manifest__.py
@@ -1,0 +1,19 @@
+#  Copyright 2020 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Print datamatrix in report",
+    "summary": "Allow to print datamatrix",
+    "version": "12.0.1.0.0",
+    "category": "Generic Modules/Base",
+    "website": "https://github.com/OCA/report-print-send/tree/"
+               "12.0/print_datamatrix",
+    "author": "Agile Business Group, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "external_dependencies": {
+        "python": ['pylibdmtx'],
+    },
+    "depends": [
+        "base",
+    ],
+}

--- a/report_barcode_datamatrix/models/__init__.py
+++ b/report_barcode_datamatrix/models/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import ir_actions_report

--- a/report_barcode_datamatrix/models/ir_actions_report.py
+++ b/report_barcode_datamatrix/models/ir_actions_report.py
@@ -1,0 +1,28 @@
+#  Copyright 2020 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import io
+
+from odoo import api, models
+from pylibdmtx.pylibdmtx import encode
+from PIL import Image
+
+
+class IrActionsReport (models.Model):
+    _inherit = 'ir.actions.report'
+
+    @api.model
+    def barcode(self, barcode_type, value,
+                width=600, height=100, humanreadable=0):
+
+        if barcode_type == 'AutoDatamatrix':
+            encoded = encode(value.encode('utf8'))
+            img_size = (encoded.width, encoded.height)
+            img = Image.frombytes('RGB', img_size, encoded.pixels)
+            with io.BytesIO() as output:
+                img.save(output, format="PNG")
+                return output.getvalue()
+
+        return super().barcode(
+            barcode_type, value,
+            width=width, height=height, humanreadable=humanreadable)

--- a/report_barcode_datamatrix/readme/DESCRIPTION.rst
+++ b/report_barcode_datamatrix/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module adds a new barcode type 'AutoDatamatrix'.

--- a/report_barcode_datamatrix/readme/INSTALL.rst
+++ b/report_barcode_datamatrix/readme/INSTALL.rst
@@ -1,0 +1,3 @@
+This module uses the Python library https://pypi.org/project/pylibdmtx/.
+
+Please see its installation instructions in order to install it.

--- a/report_barcode_datamatrix/readme/ROADMAP.rst
+++ b/report_barcode_datamatrix/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Add more datamatrix types, also using the size received by `barcode` method.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 zpl2>=1.1
 pycups==1.9.73
+pylibdmtx


### PR DESCRIPTION
Add new module to print_datamatrix.

In Odoo core already exists type 'ECC200DataMatrix' that can be printed but it is very limited, also according to its own documentation in https://pypi.org/project/reportlab/ (installed with Odoo):
```
class ECC200DataMatrix(Barcode):
    '''This code only supports a Type 12 (44x44) C40 encoded data matrix.
    This is the size and encoding that Royal Mail wants on all mail from October 1st 2015.
    see https://bitbucket.org/rptlab/reportlab/issues/69/implementations-of-code-128-auto-and-data
    '''
```

Specifically, it limits the length of the value to be printed to 144 chars.

