### PR TITLE
[8.0] Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pycups>=1.9.68
+pycups<2
 PyPDF2==1.18
 requests


### PR DESCRIPTION
Remove support to python 2
https://github.com/OpenPrinting/pycups/blob/master/NEWS