### PR TITLE
[13.0] [FIX] base_report_to_printer: add dependency on mail

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -14,7 +14,7 @@
     " Open for Small Business Ltd",
     "website": "https://github.com/OCA/report-print-send",
     "license": "AGPL-3",
-    "depends": ["web"],
+    "depends": ["mail", "web"],
     "data": [
         "data/printing_data.xml",
         "security/security.xml",


### PR DESCRIPTION
On existing installations, the cron creation fails because of the activity_user_type required field.
Adding a dependency on the mail module solved the problem.