### PR TITLE
[FIX] base_report_to_printer: 1030: The printer or class does not exist

### DIFF
--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -36,6 +36,8 @@ class PrintingServer(models.Model):
         self.ensure_one()
         connection = False
         try:
+            cups.setServer(self.address)
+            cups.setPort(self.port)
             connection = cups.Connection(host=self.address, port=self.port)
         except Exception:
             message = _(


### PR DESCRIPTION
Before this commit a error 1030: The printer or class does not exist because cups tried to print using uri printer
now configuring cups.setServer and cups.setPort as recommended at
http://nagyak.eastron.hu/doc/system-config-printer-libs-1.2.4/pycups-1.9.51/html/cups.Connection-class.html

it's working well