### PR TITLE
[IMP] 14.0 base_report_to_printer: improve job title

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -4,8 +4,10 @@
 # Copyright (C) 2011 Domsense srl (<http://www.domsense.com>)
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import time
 
 from odoo import _, api, exceptions, fields, models
+from odoo.tools import safe_eval
 
 
 class IrActionsReport(models.Model):
@@ -106,6 +108,17 @@ class IrActionsReport(models.Model):
 
         if not printer:
             raise exceptions.Warning(_("No printer configured to print this report."))
+        if self.print_report_name:
+            report_file_names = [
+                safe_eval(self.print_report_name, {"object": obj, "time": time})
+                for obj in self.env[self.model].browse(record_ids)
+            ]
+            title = " ".join(report_file_names)
+            if len(title) > 80:
+                title = title[:80] + "…"
+        else:
+            title = self.report_name
+        behaviour["title"] = title
         # TODO should we use doc_format instead of report_type
         return printer.print_document(
             self, document, doc_format=self.report_type, **behaviour

--- a/base_report_to_printer/readme/CONFIGURE.rst
+++ b/base_report_to_printer/readme/CONFIGURE.rst
@@ -2,3 +2,11 @@ To configure this module, you need to:
 
 #. Enable the "Printing / Print User" option under access
    rights to give users the ability to view the print menu.
+
+
+The jobs will be sent to the printer with a name matching the print_report_name
+of the report (truncated at 80 characters). By default this will not be
+displayed by CUPS web interface or in Odoo. To see this information, you need
+to change the configuration of your CUPS server and set the JobPrivateValue
+directive to "job-name", and reload the server. See `cupsd.conf(5)
+<https://www.cups.org/doc/man-cupsd.conf.html>` for details.

--- a/base_report_to_printer/readme/CONTRIBUTORS.rst
+++ b/base_report_to_printer/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Jairo Llopis <jairo.llopis@tecnativa.com>
 * Graeme Gellatly <graeme@o4sb.com>
 * Rod Schouteden <rod@schout-it.be>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>


### PR DESCRIPTION
instead of sending a temporary random file name as the title of the job,
use the report file name. Since this is not displayed by default by
cups, document how to configure the CUPS server so that the information
can be displayed.

Clean up the temporary file after printing to avoid cluttering the
server in the long run.