### PR TITLE
[14.0][FIX] base_report_to_printer: Don't use safe_eval as module / Add text print

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -9,6 +9,8 @@ from time import time
 from odoo import _, api, exceptions, fields, models
 from odoo.tools.safe_eval import safe_eval
 
+REPORT_TYPES = {"qweb-pdf": "pdf", "qweb-text": "text"}
+
 
 class IrActionsReport(models.Model):
     _inherit = "ir.actions.report"
@@ -99,10 +101,17 @@ class IrActionsReport(models.Model):
         return result
 
     def print_document(self, record_ids, data=None):
-        """Print a document, do not return the document file"""
-        document, doc_format = self.with_context(
-            must_skip_send_to_printer=True
-        )._render_qweb_pdf(record_ids, data=data)
+        """ Print a document, do not return the document file """
+        report_type = REPORT_TYPES.get(self.report_type)
+        if not report_type:
+            raise exceptions.UserError(
+                _("This report type (%s) is not supported by direct printing!")
+                % str(self.report_type)
+            )
+        method_name = "_render_qweb_%s" % (report_type)
+        document, doc_format = getattr(
+            self.with_context(must_skip_send_to_printer=True), method_name
+        )(record_ids, data=data)
         behaviour = self.behaviour()
         printer = behaviour.pop("printer", None)
 

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -7,7 +7,7 @@
 import time
 
 from odoo import _, api, exceptions, fields, models
-from odoo.tools import safe_eval
+from odoo.tools.safe_eval import safe_eval
 
 
 class IrActionsReport(models.Model):

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -160,3 +160,22 @@ class IrActionsReport(models.Model):
             )
 
         return document, doc_format
+
+    def _render_qweb_text(self, docids, data=None):
+        """Generate a TEXT file and returns it.
+
+        If the action configured on the report is server, it prints the
+        generated document as well.
+        """
+        document, doc_format = super()._render_qweb_text(docids=docids, data=data)
+
+        behaviour = self.behaviour()
+        printer = behaviour.pop("printer", None)
+        can_print_report = self._can_print_report(behaviour, printer, document)
+
+        if can_print_report:
+            printer.print_document(
+                self, document, doc_format=self.report_type, **behaviour
+            )
+
+        return document, doc_format

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -101,7 +101,7 @@ class IrActionsReport(models.Model):
         return result
 
     def print_document(self, record_ids, data=None):
-        """ Print a document, do not return the document file """
+        """Print a document, do not return the document file"""
         report_type = REPORT_TYPES.get(self.report_type)
         if not report_type:
             raise exceptions.UserError(

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2011 Domsense srl (<http://www.domsense.com>)
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import time
+from time import time
 
 from odoo import _, api, exceptions, fields, models
 from odoo.tools.safe_eval import safe_eval

--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -9,7 +9,7 @@ odoo.define("base_report_to_printer.print", function (require) {
         _triggerDownload: function (action, options, type) {
             var self = this;
             var _super = this._super;
-            if (type === "pdf") {
+            if (type === "pdf" || "text") {
                 this._rpc({
                     model: "ir.actions.report",
                     method: "print_action_for_report_name",
@@ -49,9 +49,9 @@ odoo.define("base_report_to_printer.print", function (require) {
                         return _super.apply(self, [action, options, type]);
                     }
                 });
-            } else {
-                return _super.apply(self, [action, options, type]);
+                return Promise.reject();
             }
+            return _super.apply(self, [action, options, type]);
         },
     });
 });

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -43,6 +43,14 @@ class TestReport(common.HttpCase):
                 "report_name": "base_report_to_printer.test",
             }
         )
+        self.report_text = self.Model.create(
+            {
+                "name": "Test",
+                "report_type": "qweb-text",
+                "model": "res.partner",
+                "report_name": "base_report_to_printer.test",
+            }
+        )
         self.partners = self.env["res.partner"]
         for n in range(5):
             self.partners += self.env["res.partner"].create({"name": "Test %d" % n})
@@ -106,6 +114,24 @@ class TestReport(common.HttpCase):
                 document[0],
                 action="server",
                 doc_format="qweb-pdf",
+                tray=False,
+            )
+
+    def test_render_qweb_text_printable(self):
+        """It should print the report, only if it is printable"""
+        with mock.patch(
+            "odoo.addons.base_report_to_printer.models."
+            "printing_printer.PrintingPrinter."
+            "print_document"
+        ) as print_document:
+            self.report_text.property_printing_action_id.action_type = "server"
+            self.report_text.printing_printer_id = self.new_printer()
+            document = self.report_text._render_qweb_text(self.partners.ids)
+            print_document.assert_called_once_with(
+                self.report_text,
+                document[0],
+                action="server",
+                doc_format="qweb-text",
                 tray=False,
             )
 


### PR DESCRIPTION
Adds:

- [x] Don't use safe_eval as module (Exception raised) introduced there https://github.com/OCA/report-print-send/pull/261 @gurneyalex 
- [x] Add a text printing feature
- [x] Add tests for text printing