### PR TITLE
fix(#259): handle case of print attachment wizard

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -82,7 +82,8 @@ The jobs will be sent to the printer with a name matching the print_report_name
 of the report (truncated at 80 characters). By default this will not be
 displayed by CUPS web interface or in Odoo. To see this information, you need
 to change the configuration of your CUPS server and set the JobPrivateValue
-directive to "job-name", and reload the server. See `cupsd.conf(5)
+directive to "none" (or some other list of values which does not include
+"job-name") , and reload the server. See `cupsd.conf(5)
 <https://www.cups.org/doc/man-cupsd.conf.html>` for details.
 
 Usage

--- a/base_report_to_printer/readme/CONFIGURE.rst
+++ b/base_report_to_printer/readme/CONFIGURE.rst
@@ -8,5 +8,6 @@ The jobs will be sent to the printer with a name matching the print_report_name
 of the report (truncated at 80 characters). By default this will not be
 displayed by CUPS web interface or in Odoo. To see this information, you need
 to change the configuration of your CUPS server and set the JobPrivateValue
-directive to "job-name", and reload the server. See `cupsd.conf(5)
+directive to "none" (or some other list of values which does not include
+"job-name") , and reload the server. See `cupsd.conf(5)
 <https://www.cups.org/doc/man-cupsd.conf.html>` for details.

--- a/base_report_to_printer/wizards/print_attachment_report.py
+++ b/base_report_to_printer/wizards/print_attachment_report.py
@@ -25,6 +25,7 @@ class PrintAttachment(models.TransientModel):
         errors = []
         for att_line in self.attachment_line_ids:
             data = att_line.attachment_id.datas
+            title = att_line.attachment_id.datas_fname
             if not data:
                 errors.append(att_line)
                 continue
@@ -34,7 +35,8 @@ class PrintAttachment(models.TransientModel):
                 None,
                 content=content,
                 format=content_format,
-                copies=att_line.copies
+                copies=att_line.copies,
+                title=title
             )
         if errors:
             return {


### PR DESCRIPTION
The fix in #259 only worked for reports being printed at generation
of the PDF. This PR handles sending an attachment to a printer through
the Print Attachment wizard.