### PR TITLE
[14.0][IMP] base_report_to_printer: Add support for py3o report type

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -9,7 +9,7 @@ from time import time
 from odoo import _, api, exceptions, fields, models
 from odoo.tools.safe_eval import safe_eval
 
-REPORT_TYPES = {"qweb-pdf": "pdf", "qweb-text": "text"}
+REPORT_TYPES = {"qweb-pdf": "qweb_pdf", "qweb-text": "qweb_text", "py3o" : "py3o"}
 
 
 class IrActionsReport(models.Model):
@@ -108,7 +108,7 @@ class IrActionsReport(models.Model):
                 _("This report type (%s) is not supported by direct printing!")
                 % str(self.report_type)
             )
-        method_name = "_render_qweb_%s" % (report_type)
+        method_name = "_render_%s" % (report_type)
         document, doc_format = getattr(
             self.with_context(must_skip_send_to_printer=True), method_name
         )(record_ids, data=data)


### PR DESCRIPTION
We needed to add the "py3o" report type. In order to do this, we modified the `method_name`'s allocation method and the `REPORT_TYPES` constant so that they meet our needs.
As it can be useful to other people, we propose the enhancement in PR.