### PR TITLE
[14.0][FIX] base_report_to_printer: Manage to distinguish a print from a display

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -50,10 +50,16 @@ class IrActionsReport(models.Model):
         if not report:
             return {}
         result = report.behaviour()
-        serializable_result = {
-            "action": result["action"],
-            "printer_name": result["printer"].name,
-        }
+        if self.env.context.get("must_skip_send_to_printer"):
+            serializable_result = {
+                "action": "client",
+                "printer_name": False,
+            }
+        else:
+            serializable_result = {
+                "action": result["action"],
+                "printer_name": result["printer"].name,
+            }
         return serializable_result
 
     def _get_user_default_print_behaviour(self):

--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -14,6 +14,7 @@ odoo.define("base_report_to_printer.print", function (require) {
                     model: "ir.actions.report",
                     method: "print_action_for_report_name",
                     args: [action.report_name],
+                    context: action.context,
                 }).then(function (print_action) {
                     if (print_action && print_action.action === "server") {
                         self._rpc({


### PR DESCRIPTION
Foremost, maybe we are wrong about how to use `must_skip_send_to_printer`.
When we tried to use it in the context, in order to not print a report, we realized that the context was lost during the `print_action_for_report_name()`'s call. Also, we think a direct distinction of printing and displayed in `print_action_for_report_name()` is more correct.