### PR TITLE
[IMP] report print send allow print multiple reports types

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -41,12 +41,18 @@ class IrActionsReport(models.Model):
         self.printer_tray_id = False
 
     @api.model
-    def print_action_for_report_name(self, report_name):
+    def _get_report_from_id(self, report_id):
+        report_obj = self.env['ir.actions.report']
+        context = self.env['res.users'].context_get()
+        return report_obj.with_context(context).sudo().search(report_id, limit=1)
+
+    @api.model
+    def print_action_for_report(self, report_id):
         """Returns if the action is a direct print or pdf
 
         Called from js
         """
-        report = self._get_report_from_name(report_name)
+        report = self._get_report_from_id(report_id)
         if not report:
             return {}
         result = report.behaviour()
@@ -115,7 +121,8 @@ class IrActionsReport(models.Model):
         behaviour = self.behaviour()
         printer = behaviour.pop("printer", None)
 
-        if not printer:
+        if not printer and self.property_printing_action_id.action_type != "client":
+            import pdb; pdb.set_trace()
             raise exceptions.UserError(_("No printer configured to print this report."))
         if self.print_report_name:
             report_file_names = [

--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -12,8 +12,8 @@ odoo.define("base_report_to_printer.print", function (require) {
             if (type === "pdf" || "text") {
                 this._rpc({
                     model: "ir.actions.report",
-                    method: "print_action_for_report_name",
-                    args: [action.report_name],
+                    method: "print_action_for_report",
+                    args: [action.id],
                 }).then(function (print_action) {
                     if (print_action && print_action.action === "server") {
                         self._rpc({

--- a/base_report_to_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_printer/tests/test_ir_actions_report.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from odoo.tests.common import TransactionCase
 
-model = "odoo.addons.base.models.ir_actions_report.IrActionsReport"
+model = "odoo.addons.base_report_to_printer.models.ir_actions_report.IrActionsReport"
 
 
 class TestIrActionsReportXml(TransactionCase):
@@ -53,25 +53,25 @@ class TestIrActionsReportXml(TransactionCase):
             values.update(vals)
         return self.env["printing.tray"].create(values)
 
-    def test_print_action_for_report_name_gets_report(self):
-        """It should get report by name"""
-        with mock.patch("%s._get_report_from_name" % model) as mk:
+    def test_print_action_for_report_gets_report(self):
+        """It should get report by action"""
+        with mock.patch("%s._get_report_from_id" % model) as mk:
             expect = "test"
-            self.Model.print_action_for_report_name(expect)
+            self.Model.print_action_for_report(expect)
             mk.assert_called_once_with(expect)
 
-    def test_print_action_for_report_name_returns_if_no_report(self):
+    def test_print_action_for_report_returns_if_no_report(self):
         """It should return empty dict when no matching report"""
-        with mock.patch("%s._get_report_from_name" % model) as mk:
+        with mock.patch("%s._get_report_from_id" % model) as mk:
             expect = "test"
             mk.return_value = False
-            res = self.Model.print_action_for_report_name(expect)
+            res = self.Model.print_action_for_report(expect)
             self.assertDictEqual({}, res)
 
-    def test_print_action_for_report_name_returns_if_report(self):
+    def test_print_action_for_report_returns_if_report(self):
         """It should return correct serializable result for behaviour"""
-        with mock.patch("%s._get_report_from_name" % model) as mk:
-            res = self.Model.print_action_for_report_name("test")
+        with mock.patch("%s._get_report_from_id" % model) as mk:
+            res = self.Model.print_action_for_report("test")
             behaviour = mk().behaviour()
             expect = {
                 "action": behaviour["action"],


### PR DESCRIPTION
Allow to print the same report in multiple report types  and behaviour (send to client or send to printer)

![image](https://user-images.githubusercontent.com/67733397/181765141-bf4f6b4b-b420-4638-a645-4210575b5298.png)

Currently we are only able to set 1 report type because the method `_get_report_from_name` it always takes the first report found by repor_name:
https://github.com/odoo/odoo/blob/0ab552a749e3fc4aa6c549909ccece3821c4cd09/odoo/addons/base/models/ir_actions_report.py#L498

The proposed solution is to send in the `.js` call the action linked to the report directly.
