### PR TITLE
[IMP] report print send allow print multiple reports types

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -41,12 +41,29 @@ class IrActionsReport(models.Model):
         self.printer_tray_id = False
 
     @api.model
-    def print_action_for_report_name(self, report_name):
-        """Returns if the action is a direct print or pdf
+    def _get_report_for_id(self, report_id):
+        report_obj = self.env["ir.actions.report"]
+        conditions = [("id", "=", report_id)]
+        context = self.env["res.users"].context_get()
+        return report_obj.with_context(context).sudo().search(conditions, limit=1)
+
+    @api.model
+    def print_action_for_report_id(self, report_id):
+        """Returns if the action is a direct print or pdf (get action by report_id)
 
         Called from js
         """
+        report = self._get_report_for_id(report_id)
+        return self._print_action_from_report(report)
+
+    @api.model
+    def print_action_for_report_name(self, report_name):
+        """Returns if the action is a direct print or pdf (get action by report_name)"""
         report = self._get_report_from_name(report_name)
+        return self._print_action_from_report(report)
+
+    @api.model
+    def _print_action_from_report(self, report):
         if not report:
             return {}
         result = report.behaviour()

--- a/base_report_to_printer/static/src/js/qweb_action_manager.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.js
@@ -12,8 +12,8 @@ odoo.define("base_report_to_printer.print", function (require) {
             if (type === "pdf" || "text") {
                 this._rpc({
                     model: "ir.actions.report",
-                    method: "print_action_for_report_name",
-                    args: [action.report_name],
+                    method: "print_action_for_report_id",
+                    args: [action.id],
                 }).then(function (print_action) {
                     if (print_action && print_action.action === "server") {
                         self._rpc({

--- a/base_report_to_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_printer/tests/test_ir_actions_report.py
@@ -7,6 +7,9 @@ from unittest import mock
 from odoo.tests.common import TransactionCase
 
 model = "odoo.addons.base.models.ir_actions_report.IrActionsReport"
+base_report_to_printer_model = (
+    "odoo.addons.base_report_to_printer.models.ir_actions_report.IrActionsReport"
+)
 
 
 class TestIrActionsReportXml(TransactionCase):
@@ -78,6 +81,21 @@ class TestIrActionsReportXml(TransactionCase):
                 "printer_name": behaviour["printer"].name,
             }
             self.assertDictEqual(expect, res, "Expect {}, Got {}".format(expect, res))
+
+    def test_print_action_for_report_id_gets_report(self):
+        """It should get report by action id"""
+        with mock.patch("%s._get_report_for_id" % base_report_to_printer_model) as mk:
+            expect = "test"
+            self.Model.print_action_for_report_id(expect)
+            mk.assert_called_once_with(expect)
+
+    def test_print_action_for_report_returns_if_no_report_id(self):
+        """It should return empty dict when no matching report"""
+        with mock.patch("%s._get_report_for_id" % base_report_to_printer_model) as mk:
+            expect = "test"
+            mk.return_value = False
+            res = self.Model.print_action_for_report_id(expect)
+            self.assertDictEqual({}, res)
 
     def test_behaviour_default_values(self):
         """It should return the default action and printer"""


### PR DESCRIPTION
Allow to print the same report in multiple report types  and behaviour (send to client or send to printer)

![image](https://user-images.githubusercontent.com/67733397/181765141-bf4f6b4b-b420-4638-a645-4210575b5298.png)

Currently we are only able to set 1 report type because the method `_get_report_from_name` it always takes the first report found by repor_name:
https://github.com/odoo/odoo/blob/0ab552a749e3fc4aa6c549909ccece3821c4cd09/odoo/addons/base/models/ir_actions_report.py#L498

The proposed solution is to send in the `.js` call the action linked to the report directly.
