### PR TITLE
[13.0][FIX] base_report_to_printer: fix result of print_action behaviour

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -80,22 +80,23 @@ class IrActionsReport(models.Model):
         self.ensure_one()
         printing_act_obj = self.env["printing.report.xml.action"]
 
-        result = self._get_user_default_print_behaviour()
-        result.update(self._get_report_default_print_behaviour())
-
         # Retrieve report-user specific values
         print_action = printing_act_obj.search(
             [
                 ("report_id", "=", self.id),
                 ("user_id", "=", self.env.uid),
-                ("action", "!=", "user_default"),
             ],
             limit=1,
         )
-        if print_action:
-            # For some reason design takes report defaults over
-            # False action entries so we must allow for that here
+
+        result = self._get_user_default_print_behaviour()
+
+        if not print_action:
+            result.update(self._get_report_default_print_behaviour())
+
+        elif print_action.action != 'user_default':
             result.update({k: v for k, v in print_action.behaviour().items() if v})
+
         return result
 
     def print_document(self, record_ids, data=None):

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -94,7 +94,7 @@ class IrActionsReport(models.Model):
         if not print_action:
             result.update(self._get_report_default_print_behaviour())
 
-        elif print_action.action != 'user_default':
+        elif print_action.action != "user_default":
             result.update({k: v for k, v in print_action.behaviour().items() if v})
 
         return result


### PR DESCRIPTION
- Current behavior:
Print Actions of Reports with action: **Use user's defaults** not using the Print Action added in User Preference if you have Default Behaviour set in the Report.

- Expected behavior:
Print Actions of Reports with action: **Use user's defaults** uses the Print Action added in User Preference, no matter if you have Default Behaviour set in the Report.