### PR TITLE
[16.0] base_report_to_printer: fix views

### DIFF
--- a/base_report_to_printer/views/printing_printer.xml
+++ b/base_report_to_printer/views/printing_printer.xml
@@ -62,12 +62,14 @@
                             string="Set Default"
                             type="object"
                             attrs="{'invisible': [('default','=', True)]}"
+                            colspan="2"
                         />
                         <button
                             name="unset_default"
                             string="Unset Default"
                             type="object"
                             attrs="{'invisible': [('default','=', False)]}"
+                            colspan="2"
                         />
                     </group>
                     <group name="details">
@@ -78,7 +80,7 @@
                         <field name="status_message" />
                     </group>
                     <group string="Trays" name="trays">
-                        <field name="tray_ids" nolabel="1">
+                        <field name="tray_ids" nolabel="1" colspan="2">
                             <form>
                                 <group name="name_fields">
                                     <field name="name" />
@@ -87,9 +89,8 @@
                             </form>
                         </field>
                     </group>
-                    <group name="jobs">
-                        <separator string="Jobs" colspan="2" />
-                        <field name="job_ids" nolabel="1" />
+                    <group name="jobs" string="Jobs">
+                        <field name="job_ids" nolabel="1" colspan="2" />
                     </group>
                 </sheet>
             </form>

--- a/base_report_to_printer/views/printing_server.xml
+++ b/base_report_to_printer/views/printing_server.xml
@@ -32,9 +32,8 @@
                         <field name="password" />
                         <field name="encryption_policy" />
                     </group>
-                    <group>
-                        <separator string="Printers" colspan="2" />
-                        <field name="printer_ids" nolabel="1" />
+                    <group name="printers" string="Printers">
+                        <field name="printer_ids" nolabel="1" colspan="2" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
The views were not adapted to v16 during the v16 migration https://github.com/OCA/report-print-send/pull/307 (no comment !)

![bug_view_base_report_to_printer](https://user-images.githubusercontent.com/1157917/225947639-f74eee23-c9e1-4871-a7d5-1551ccf3ed63.png)
