### PR TITLE
[16.0][IMP] base_report_to_printer: Add neutralization queries

### DIFF
--- a/base_report_to_printer/data/neutralize.sql
+++ b/base_report_to_printer/data/neutralize.sql
@@ -1,0 +1,2 @@
+update printing_server set active=false;
+update printing_printer set active=false;


### PR DESCRIPTION
### Before this PR
There is no way to neutralize printers and printer server using neutralization function

### After this PR
Since 16.0 of codebase there is a new function "Neutralization" that runs all neutralization queries that basically deactivate ir_cron, ir_mail_server and other production stuff. With this PR i ADD neutralization queries  that deactivates printing server and printer during neutralization .