### PR TITLE
[15.0][FIX] base_report_to_printer: update printers wizard

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -18,6 +18,7 @@
     "data": [
         "data/printing_data.xml",
         "security/security.xml",
+        "security/ir.model.access.csv",
         "views/printing_printer.xml",
         "views/printing_server.xml",
         "views/printing_job.xml",

--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -70,7 +70,7 @@ class PrintingPrinter(models.Model):
     def _prepare_update_from_cups(self, cups_connection, cups_printer):
         mapping = {3: "available", 4: "printing", 5: "error"}
         cups_vals = {
-            "name": cups_printer["printer-info"],
+            "name": self.name or cups_printer["printer-info"],
             "model": cups_printer.get("printer-make-and-model", False),
             "location": cups_printer.get("printer-location", False),
             "uri": cups_printer.get("device-uri", False),

--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -121,6 +121,11 @@ class PrintingServer(models.Model):
                     printer_values["server_id"] = server.id
 
                 updated_printers.append(name)
+                # We want to keep any existing customized name over existing printer
+                # We want also to rely in the system name as a fallback to avoid
+                # empty names.
+                if not printer_values.get("name") and not printer.name:
+                    printer_values["name"] = name
                 if not printer:
                     printer_values["system_name"] = name
                     printer.create(printer_values)

--- a/base_report_to_printer/security/ir.model.access.csv
+++ b/base_report_to_printer/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_printing_printer_update_wizard,printers update,model_printing_printer_update_wizard,base.group_system,1,1,1,1

--- a/base_report_to_printer/tests/test_printing_printer_tray.py
+++ b/base_report_to_printer/tests/test_printing_printer_tray.py
@@ -40,7 +40,7 @@ class TestPrintingPrinter(TransactionCase):
         self.server = self.env["printing.server"].create({})
         self.printer = self.env["printing.printer"].create(
             {
-                "name": "Printer",
+                "name": "",
                 "server_id": self.server.id,
                 "system_name": "Sys Name",
                 "default": True,
@@ -105,10 +105,11 @@ class TestPrintingPrinter(TransactionCase):
         Check that the update_printers method calls _prepare_update_from_cups
         """
         self.mock_cups_ppd(cups, file_name=False)
-
-        self.assertEqual(self.printer.name, "Printer")
         self.ServerModel.update_printers()
         self.assertEqual(self.printer.name, "info")
+        self.printer.name = "My custom name"
+        self.ServerModel.update_printers()
+        self.assertEqual(self.printer.name, "My custom name")
 
     @mock.patch("%s.cups" % server_model)
     def test_prepare_update_from_cups_no_ppd(self, cups):


### PR DESCRIPTION
- Add access rules to the wizard
- Set a fallback name for the printers and respect the user custom ones

cc @Tecnativa TT45159

please review @carlosdauden @sergio-teruel 