### PR TITLE
[16.0][FIX] base_report_to_printer: fix encoding

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2011 Domsense srl (<http://www.domsense.com>)
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # Copyright (C) 2016 SYLEAM (<http://www.syleam.fr>)
+# Copyright (C) 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import errno
@@ -137,6 +138,8 @@ class PrintingPrinter(models.Model):
         """
         self.ensure_one()
         fd, file_name = mkstemp()
+        if isinstance(content, str):
+            content = content.encode()
         try:
             os.write(fd, content)
         finally:

--- a/base_report_to_printer/readme/CONTRIBUTORS.rst
+++ b/base_report_to_printer/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
 * Matias Peralta <mnp@adhoc.com.ar>
 * Hughes Damry <hughes.damry@acsone.eu>
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -191,3 +191,13 @@ class TestReport(common.HttpCase):
         """It should raise an error"""
         with self.assertRaises(exceptions.UserError):
             self.report.print_document(self.partners.ids)
+
+    def test_print_document_string(self):
+        """Test string encoding"""
+        with mock.patch(
+            "odoo.addons.base_report_to_printer.models."
+            "printing_printer.PrintingPrinter."
+            "print_file"
+        ) as print_file:
+            self.new_printer().print_document("", "test")
+            print_file.assert_called_once()


### PR DESCRIPTION
In Python3, os.write requires bytes-like object

cc @lmignon @rousseldenis 