### PR TITLE
[16.0][FIX] printer_zpl2: Do use colspan=2 for the ace widget fields so you can use it

### DIFF
--- a/printer_zpl2/views/printing_label_zpl2.xml
+++ b/printer_zpl2/views/printing_label_zpl2.xml
@@ -149,6 +149,7 @@
                                             widget="ace"
                                             options="{'mode': 'python'}"
                                             nolabel="1"
+                                            colspan="2"
                                         />
                                     </group>
                                     <notebook colspan="4">
@@ -302,6 +303,7 @@
                                     widget="ace"
                                     options="{'mode': 'python'}"
                                     attrs="{'invisible':[('test_print_mode', '=', False), ('test_labelary_mode', '=', False)]}"
+                                    colspan="2"
                                 />
                             </group>
                         </page>

--- a/printer_zpl2/wizard/wizard_import_zpl2.xml
+++ b/printer_zpl2/wizard/wizard_import_zpl2.xml
@@ -12,7 +12,7 @@
                     </group>
                 </group>
                 <group string="ZPL2">
-                    <field name="data" widget="ace" nolabel="1" />
+                    <field name="data" widget="ace" nolabel="1" colspan="2" />
                 </group>
                 <footer>
                     <button string="Cancel" class="btn-default" special="cancel" />


### PR DESCRIPTION
Some minor form view fixes - without colspan="2" the ace widget is not useable