### PR TITLE
[16.0] [FIX] printer_zpl2: do not requirer access on ir.model

### DIFF
--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -368,7 +368,7 @@ class PrintingLabelZpl2(models.Model):
 
     def print_label(self, printer, record, page_count=1, **extra):
         for label in self:
-            if record._name != label.model_id.model:
+            if record._name != label.model_id.sudo().model:
                 raise exceptions.UserError(
                     _("This label cannot be used on {model}").format(model=record._name)
                 )


### PR DESCRIPTION
This fix prevents an AccessError on ir.model.