### PR TITLE
[IMP] base_report_to_printer: Paperformat

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -63,6 +63,8 @@ class PrintingPrinter(models.Model):
     model = fields.Char(readonly=True)
     location = fields.Char(readonly=True)
     uri = fields.Char(string="URI", readonly=True)
+    paperformat_id = fields.Many2one("report.paperformat")
+    fit_to_page = fields.Boolean()
     tray_ids = fields.One2many(
         comodel_name="printing.tray", inverse_name="printer_id", string="Paper Sources"
     )
@@ -170,6 +172,13 @@ class PrintingPrinter(models.Model):
                 options.update(getattr(self, "_set_option_%s" % option)(report, value))
             except AttributeError:
                 options[option] = str(value)
+
+        if self.paperformat_id:
+            width = int(self.paperformat_id.print_page_width)
+            height = int(self.paperformat_id.print_page_height)
+            options["media"] = f"Custom.{width}x{height}mm"
+        if self.fit_to_page:
+            options["fit-to-page"] = ""
         return options
 
     def print_file(self, file_name, report=None, **print_opts):

--- a/base_report_to_printer/views/printing_printer.xml
+++ b/base_report_to_printer/views/printing_printer.xml
@@ -77,6 +77,10 @@
                         <field name="status" />
                         <field name="status_message" />
                     </group>
+                    <group name="options">
+                        <field name="paperformat_id" />
+                        <field name="fit_to_page" />
+                    </group>
                     <group string="Trays" name="trays">
                         <field name="tray_ids" nolabel="1">
                             <form>


### PR DESCRIPTION
This PR allows to enforce the paperformat while printing with a specific printer. It also allows to set the fit-to-page option.