### PR TITLE
[17.0][IMP] base_report_to_printer : add output_tray

### DIFF
--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Report to printer",
-    "version": "17.0.1.1.1",
+    "version": "17.0.1.1.2",
     "category": "Generic Modules/Base",
     "author": "Agile Business Group & Domsense, Pegueroles SCP, NaN,"
     " LasLabs, Camptocamp, Odoo Community Association (OCA),"

--- a/base_report_to_printer/migrations/17.0.1.1.2/pre-migration.py
+++ b/base_report_to_printer/migrations/17.0.1.1.2/pre-migration.py
@@ -1,0 +1,32 @@
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    openupgrade.rename_models(cr, [("printing.tray", "printing.tray.input")])
+    openupgrade.rename_tables(cr, [("printing_tray", "printing_tray_input")])
+    openupgrade.rename_fields(
+        cr,
+        [
+            (
+                "ir.actions.report",
+                "ir_actions_report",
+                "printer_tray_id",
+                "printer_input_tray_id",
+                None,
+            ),
+            (
+                "printing.report.xml.action",
+                "printing_report_xml_action",
+                "printer_tray_id",
+                "printer_input_tray_id",
+                None,
+            ),
+            (
+                "res.users",
+                "res_users",
+                "printer_tray_id",
+                "printer_input_tray_id",
+                None,
+            ),
+        ],
+    )

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -24,9 +24,14 @@ class IrActionsReport(models.Model):
     printing_printer_id = fields.Many2one(
         comodel_name="printing.printer", string="Default Printer"
     )
-    printer_tray_id = fields.Many2one(
-        comodel_name="printing.tray",
+    printer_input_tray_id = fields.Many2one(
+        comodel_name="printing.tray.input",
         string="Paper Source",
+        domain="[('printer_id', '=', printing_printer_id)]",
+    )
+    printer_output_tray_id = fields.Many2one(
+        comodel_name="printing.tray.output",
+        string="Output Bin",
         domain="[('printer_id', '=', printing_printer_id)]",
     )
     printing_action_ids = fields.One2many(
@@ -39,7 +44,8 @@ class IrActionsReport(models.Model):
     @api.onchange("printing_printer_id")
     def onchange_printing_printer_id(self):
         """Reset the tray when the printer is changed"""
-        self.printer_tray_id = False
+        self.printer_input_tray_id = False
+        self.printer_output_tray_id = False
 
     @api.model
     def print_action_for_report_name(self, report_name):
@@ -69,8 +75,11 @@ class IrActionsReport(models.Model):
         return dict(
             action=user.printing_action or "client",
             printer=user.printing_printer_id or printer_obj.get_default(),
-            tray=str(user.printer_tray_id.system_name)
-            if user.printer_tray_id
+            input_tray=str(user.printer_input_tray_id.system_name)
+            if user.printer_input_tray_id
+            else False,
+            output_tray=str(user.printer_output_tray_id.system_name)
+            if user.printer_output_tray_id
             else False,
         )
 
@@ -81,8 +90,10 @@ class IrActionsReport(models.Model):
             result["action"] = report_action.action_type
         if self.printing_printer_id:
             result["printer"] = self.printing_printer_id
-        if self.printer_tray_id:
-            result["tray"] = self.printer_tray_id.system_name
+        if self.printer_input_tray_id:
+            result["input_tray"] = self.printer_input_tray_id.system_name
+        if self.printer_output_tray_id:
+            result["output_tray"] = self.printer_output_tray_id.system_name
         return result
 
     def behaviour(self):

--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -64,8 +64,15 @@ class PrintingPrinter(models.Model):
     model = fields.Char(readonly=True)
     location = fields.Char(readonly=True)
     uri = fields.Char(string="URI", readonly=True)
-    tray_ids = fields.One2many(
-        comodel_name="printing.tray", inverse_name="printer_id", string="Paper Sources"
+    input_tray_ids = fields.One2many(
+        comodel_name="printing.tray.input",
+        inverse_name="printer_id",
+        string="Paper Sources",
+    )
+    output_tray_ids = fields.One2many(
+        comodel_name="printing.tray.output",
+        inverse_name="printer_id",
+        string="Output trays",
     )
     multi_thread = fields.Boolean(
         compute="_compute_multi_thread", readonly=False, store=True
@@ -102,7 +109,8 @@ class PrintingPrinter(models.Model):
             return vals
 
         ppd = cups.PPD(ppd_path)
-        option = ppd.findOption("InputSlot")
+        input_options = ppd.findOption("InputSlot")
+        output_options = ppd.findOption("OutputBin")
         try:
             os.unlink(ppd_path)
         except OSError as err:
@@ -110,34 +118,35 @@ class PrintingPrinter(models.Model):
             # The file has already been deleted, we can continue the update
             if err.errno != errno.ENOENT:
                 raise
-        if not option:
-            return vals
-
-        tray_commands = []
-        cups_trays = {
-            tray_option["choice"]: tray_option["text"] for tray_option in option.choices
-        }
-
-        # Add new trays
-        tray_commands.extend(
-            [
-                (0, 0, {"name": text, "system_name": choice})
-                for choice, text in cups_trays.items()
-                if choice not in self.tray_ids.mapped("system_name")
+        if input_options:
+            vals["input_tray_ids"] = [
+                (0, 0, {"name": opt["text"], "system_name": opt["choice"]})
+                for opt in input_options.choices
+                if opt["choice"] not in self.input_tray_ids.mapped("system_name")
             ]
-        )
+            trays = [opt["choice"] for opt in input_options.choices]
+            vals["input_tray_ids"].extend(
+                [
+                    (2, tray.id)
+                    for tray in self.input_tray_ids
+                    if tray.system_name not in trays
+                ]
+            )
 
-        # Remove deleted trays
-        tray_commands.extend(
-            [
-                (2, tray.id)
-                for tray in self.tray_ids.filtered(
-                    lambda record: record.system_name not in cups_trays.keys()
-                )
+        if output_options:
+            vals["output_tray_ids"] = [
+                (0, 0, {"name": opt["text"], "system_name": opt["choice"]})
+                for opt in output_options.choices
+                if opt["choice"] not in self.output_tray_ids.mapped("system_name")
             ]
-        )
-        if tray_commands:
-            vals["tray_ids"] = tray_commands
+            trays = [opt["choice"] for opt in output_options.choices]
+            vals["output_tray_ids"].extend(
+                [
+                    (2, tray.id)
+                    for tray in self.output_tray_ids
+                    if tray.system_name not in trays
+                ]
+            )
         return vals
 
     def print_document(self, report, content, **print_opts):
@@ -162,10 +171,13 @@ class PrintingPrinter(models.Model):
     # Backwards compatibility of builtin used as kwarg
     _set_option_format = _set_option_doc_format
 
-    def _set_option_tray(self, report, value):
+    def _set_option_input_tray(self, report, value):
         """Note we use self here as some older PPD use tray
         rather than InputSlot so we may need to query printer in override"""
         return {"InputSlot": str(value)} if value else {}
+
+    def _set_option_output_tray(self, report, value):
+        return {"OutputBin": str(value)} if value else {}
 
     @staticmethod
     def _set_option_noop(report, value):

--- a/base_report_to_printer/models/printing_report_xml_action.py
+++ b/base_report_to_printer/models/printing_report_xml_action.py
@@ -27,16 +27,22 @@ class PrintingReportXmlAction(models.Model):
     )
     printer_id = fields.Many2one(comodel_name="printing.printer", string="Printer")
 
-    printer_tray_id = fields.Many2one(
-        comodel_name="printing.tray",
+    printer_input_tray_id = fields.Many2one(
+        comodel_name="printing.tray.input",
         string="Paper Source",
+        domain="[('printer_id', '=', printer_id)]",
+    )
+    printer_output_tray_id = fields.Many2one(
+        comodel_name="printing.tray.output",
+        string="Output Bin",
         domain="[('printer_id', '=', printer_id)]",
     )
 
     @api.onchange("printer_id")
     def onchange_printer_id(self):
         """Reset the tray when the printer is changed"""
-        self.printer_tray_id = False
+        self.printer_input_tray_id = False
+        self.printer_output_tray_id = False
 
     def behaviour(self):
         if not self:
@@ -44,5 +50,6 @@ class PrintingReportXmlAction(models.Model):
         return {
             "action": self.action,
             "printer": self.printer_id,
-            "tray": self.printer_tray_id.system_name,
+            "input_tray": self.printer_input_tray_id.system_name,
+            "output_tray": self.printer_output_tray_id.system_name,
         }

--- a/base_report_to_printer/models/printing_tray.py
+++ b/base_report_to_printer/models/printing_tray.py
@@ -4,7 +4,7 @@
 from odoo import fields, models
 
 
-class PrinterTray(models.Model):
+class PrinterTray(models.AbstractModel):
     _name = "printing.tray"
     _description = "Printer Tray"
 
@@ -19,3 +19,15 @@ class PrinterTray(models.Model):
         readonly=True,
         ondelete="cascade",
     )
+
+
+class PrinterInputTray(models.Model):
+    _name = "printing.tray.input"
+    _description = "Printer Tray Input"
+    _inherit = "printing.tray"
+
+
+class PrinterOutputTray(models.Model):
+    _name = "printing.tray.output"
+    _description = "Printer Tray Output"
+    _inherit = "printing.tray"

--- a/base_report_to_printer/models/res_users.py
+++ b/base_report_to_printer/models/res_users.py
@@ -35,13 +35,19 @@ class ResUsers(models.Model):
             "printing_printer_id",
         ]
 
-    printer_tray_id = fields.Many2one(
-        comodel_name="printing.tray",
+    printer_input_tray_id = fields.Many2one(
+        comodel_name="printing.tray.input",
         string="Default Printer Paper Source",
+        domain="[('printer_id', '=', printing_printer_id)]",
+    )
+    printer_output_tray_id = fields.Many2one(
+        comodel_name="printing.tray.output",
+        string="Default Printer Output Bin",
         domain="[('printer_id', '=', printing_printer_id)]",
     )
 
     @api.onchange("printing_printer_id")
     def onchange_printing_printer_id(self):
         """Reset the tray when the printer is changed"""
-        self.printer_tray_id = False
+        self.printer_input_tray_id = False
+        self.printer_output_tray_id = False

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -104,8 +104,8 @@
         <field eval="0" name="perm_create" />
     </record>
     <record id="access_printing_tray_all" model="ir.model.access">
-        <field name="name">Printing Tray User</field>
-        <field name="model_id" ref="model_printing_tray" />
+        <field name="name">Printing Input Tray User</field>
+        <field name="model_id" ref="model_printing_tray_input" />
         <field name="group_id" ref="printing_group_user" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_unlink" />
@@ -113,8 +113,26 @@
         <field eval="0" name="perm_create" />
     </record>
     <record id="access_printing_tray_operator" model="ir.model.access">
-        <field name="name">Printing Tray User</field>
-        <field name="model_id" ref="model_printing_tray" />
+        <field name="name">Printing Input Tray Manager</field>
+        <field name="model_id" ref="model_printing_tray_input" />
+        <field name="group_id" ref="printing_group_manager" />
+        <field eval="1" name="perm_read" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
+        <field eval="1" name="perm_create" />
+    </record>
+    <record id="access_printing_tray_output__all" model="ir.model.access">
+        <field name="name">Printing Output Tray User</field>
+        <field name="model_id" ref="model_printing_tray_output" />
+        <field name="group_id" ref="printing_group_user" />
+        <field eval="1" name="perm_read" />
+        <field eval="0" name="perm_unlink" />
+        <field eval="0" name="perm_write" />
+        <field eval="0" name="perm_create" />
+    </record>
+    <record id="access_printing_tray_output_operator" model="ir.model.access">
+        <field name="name">Printing Output Tray Manager</field>
+        <field name="model_id" ref="model_printing_tray_output" />
         <field name="group_id" ref="printing_group_manager" />
         <field eval="1" name="perm_read" />
         <field eval="1" name="perm_unlink" />

--- a/base_report_to_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_printer/tests/test_ir_actions_report.py
@@ -49,11 +49,11 @@ class TestIrActionsReportXml(TransactionCase):
             }
         )
 
-    def new_tray(self, vals=None, defaults=None):
+    def new_tray(self, tray_type="input", vals=None, defaults=None):
         values = dict(defaults)
         if vals is not None:
             values.update(vals)
-        return self.env["printing.tray"].create(values)
+        return self.env["printing.tray." + tray_type].create(values)
 
     def test_print_action_for_report_name_gets_report(self):
         """It should get report by name"""
@@ -93,7 +93,8 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": "client",
                 "printer": self.env["printing.printer"],
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -107,7 +108,8 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": "client",
                 "printer": self.env.user.printing_printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -122,7 +124,8 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": report.property_printing_action_id.action_type,
                 "printer": report.printing_printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -133,7 +136,12 @@ class TestIrActionsReportXml(TransactionCase):
         report.property_printing_action_id.action_type = "user_default"
         self.assertEqual(
             report.behaviour(),
-            {"action": "client", "printer": report.printing_printer_id, "tray": False},
+            {
+                "action": "client",
+                "printer": report.printing_printer_id,
+                "input_tray": False,
+                "output_tray": False,
+            },
         )
 
     def test_behaviour_printing_action_on_wrong_user(self):
@@ -146,7 +154,12 @@ class TestIrActionsReportXml(TransactionCase):
         )
         self.assertEqual(
             report.behaviour(),
-            {"action": "client", "printer": report.printing_printer_id, "tray": False},
+            {
+                "action": "client",
+                "printer": report.printing_printer_id,
+                "input_tray": False,
+                "output_tray": False,
+            },
         )
 
     def test_behaviour_printing_action_on_wrong_report(self):
@@ -160,7 +173,12 @@ class TestIrActionsReportXml(TransactionCase):
         )
         self.assertEqual(
             report.behaviour(),
-            {"action": "client", "printer": report.printing_printer_id, "tray": False},
+            {
+                "action": "client",
+                "printer": report.printing_printer_id,
+                "input_tray": False,
+                "output_tray": False,
+            },
         )
 
     def test_behaviour_printing_action_with_no_printer(self):
@@ -177,7 +195,8 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": printing_action.action,
                 "printer": report.printing_printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -193,7 +212,8 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": printing_action.action,
                 "printer": printing_action.printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -208,7 +228,12 @@ class TestIrActionsReportXml(TransactionCase):
         printing_action.action = "user_default"
         self.assertEqual(
             report.behaviour(),
-            {"action": "client", "printer": report.printing_printer_id, "tray": False},
+            {
+                "action": "client",
+                "printer": report.printing_printer_id,
+                "input_tray": False,
+                "output_tray": False,
+            },
         )
 
     def test_print_tray_behaviour(self):
@@ -220,57 +245,98 @@ class TestIrActionsReportXml(TransactionCase):
             {"user_id": self.env.user.id, "report_id": report.id, "action": "server"}
         )
         printer = self.new_printer()
-        tray_vals = {"name": "Tray", "system_name": "Tray", "printer_id": printer.id}
-        user_tray = self.new_tray({"system_name": "User tray"}, tray_vals)
-        report_tray = self.new_tray({"system_name": "Report tray"}, tray_vals)
-        action_tray = self.new_tray({"system_name": "Action tray"}, tray_vals)
+        tray_vals = {
+            "name": "Tray",
+            "system_name": "Tray",
+            "printer_id": printer.id,
+        }
+        user_tray_in = self.new_tray("input", {"system_name": "User tray"}, tray_vals)
+        report_tray_in = self.new_tray(
+            "input", {"system_name": "Report tray"}, tray_vals
+        )
+        action_tray_in = self.new_tray(
+            "input", {"system_name": "Action tray"}, tray_vals
+        )
+        user_tray_out = self.new_tray("output", {"system_name": "User tray"}, tray_vals)
+        report_tray_out = self.new_tray(
+            "output", {"system_name": "Report tray"}, tray_vals
+        )
+        action_tray_out = self.new_tray(
+            "output", {"system_name": "Action tray"}, tray_vals
+        )
 
         # No report passed
-        self.env.user.printer_tray_id = False
+        self._set_trays(report, action, "input")
+        self._set_trays(report, action, "output")
         options = printer.print_options()
         self.assertFalse("InputSlot" in options)
+        self.assertFalse("OutputBin" in options)
 
         # No tray defined
-        self.env.user.printer_tray_id = False
-        report.printer_tray_id = False
-        action.printer_tray_id = False
+        self._set_trays(report, action, "input")
+        self._set_trays(report, action, "output")
         options = report.behaviour()
-        self.assertTrue("tray" in options)
+        self.assertTrue("input_tray" in options)
+        self.assertTrue("output_tray" in options)
 
         # Only user tray is defined
-        self.env.user.printer_tray_id = user_tray
-        report.printer_tray_id = False
-        action.printer_tray_id = False
-        self.assertEqual("User tray", report.behaviour()["tray"])
+        self._set_trays(report, action, "input", user_tray=user_tray_in)
+        self._set_trays(report, action, "output", user_tray=user_tray_out)
+        self.assertEqual("User tray", report.behaviour()["input_tray"])
+        self.assertEqual("User tray", report.behaviour()["output_tray"])
 
         # Only report tray is defined
-        self.env.user.printer_tray_id = False
-        report.printer_tray_id = report_tray
-        action.printer_tray_id = False
-        self.assertEqual("Report tray", report.behaviour()["tray"])
+        self._set_trays(report, action, "input", report_tray=report_tray_in)
+        self._set_trays(report, action, "output", report_tray=report_tray_out)
+        self.assertEqual("Report tray", report.behaviour()["input_tray"])
+        self.assertEqual("Report tray", report.behaviour()["output_tray"])
 
         # Only action tray is defined
-        self.env.user.printer_tray_id = False
-        report.printer_tray_id = False
-        action.printer_tray_id = action_tray
-        self.assertEqual("Action tray", report.behaviour()["tray"])
+        self._set_trays(report, action, "input", action_tray=action_tray_in)
+        self._set_trays(report, action, "output", action_tray=action_tray_out)
+        self.assertEqual("Action tray", report.behaviour()["input_tray"])
+        self.assertEqual("Action tray", report.behaviour()["output_tray"])
 
         # User and report tray defined
-        self.env.user.printer_tray_id = user_tray
-        report.printer_tray_id = report_tray
-        action.printer_tray_id = False
-        self.assertEqual("Report tray", report.behaviour()["tray"])
+        self._set_trays(report, action, "input", user_tray_in, report_tray_in)
+        self._set_trays(report, action, "output", user_tray_out, report_tray_out)
+        self.assertEqual("Report tray", report.behaviour()["input_tray"])
+        self.assertEqual("Report tray", report.behaviour()["output_tray"])
 
         # All trays are defined
-        self.env.user.printer_tray_id = user_tray
-        report.printer_tray_id = report_tray
-        action.printer_tray_id = action_tray
-        self.assertEqual("Action tray", report.behaviour()["tray"])
+        self._set_trays(
+            report, action, "input", user_tray_in, report_tray_in, action_tray_in
+        )
+        self._set_trays(
+            report, action, "output", user_tray_out, report_tray_out, action_tray_out
+        )
+        self.assertEqual("Action tray", report.behaviour()["input_tray"])
+        self.assertEqual("Action tray", report.behaviour()["output_tray"])
+
+    def _set_trays(
+        self,
+        report,
+        action,
+        tray_type="input",
+        user_tray=False,
+        report_tray=False,
+        action_tray=False,
+    ):
+        attr = "printer_" + tray_type + "_tray_id"
+        setattr(self.env.user, attr, user_tray)
+        setattr(report, attr, report_tray)
+        setattr(action, attr, action_tray)
 
     def test_onchange_printer_tray_id_empty(self):
-        action = self.Model.new({"printer_tray_id": False})
+        action = self.Model.new(
+            {
+                "printer_input_tray_id": False,
+                "printer_output_tray_id": False,
+            }
+        )
         action.onchange_printing_printer_id()
-        self.assertFalse(action.printer_tray_id)
+        self.assertFalse(action.printer_input_tray_id)
+        self.assertFalse(action.printer_output_tray_id)
 
     def test_onchange_printer_tray_id_not_empty(self):
         server = self.env["printing.server"].create({})
@@ -287,14 +353,32 @@ class TestIrActionsReportXml(TransactionCase):
                 "uri": "URI",
             }
         )
-        tray = self.env["printing.tray"].create(
-            {"name": "Tray", "system_name": "TrayName", "printer_id": printer.id}
+        input_tray = self.env["printing.tray.input"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
+        )
+        output_tray = self.env["printing.tray.output"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
         )
 
-        action = self.Model.new({"printer_tray_id": tray.id})
-        self.assertEqual(action.printer_tray_id, tray)
+        action = self.Model.new(
+            {
+                "printer_input_tray_id": input_tray.id,
+                "printer_output_tray_id": output_tray.id,
+            }
+        )
+        self.assertEqual(action.printer_input_tray_id, input_tray)
+        self.assertEqual(action.printer_output_tray_id, output_tray)
         action.onchange_printing_printer_id()
-        self.assertFalse(action.printer_tray_id)
+        self.assertFalse(action.printer_input_tray_id)
+        self.assertFalse(action.printer_output_tray_id)
 
     def test_print_in_new_thread(self):
         """It should return the action and printer from printing action in other
@@ -310,6 +394,7 @@ class TestIrActionsReportXml(TransactionCase):
             {
                 "action": printing_action.action,
                 "printer": printing_action.printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )

--- a/base_report_to_printer/tests/test_printing_printer.py
+++ b/base_report_to_printer/tests/test_printing_printer.py
@@ -38,9 +38,10 @@ class TestPrintingPrinter(TransactionCase):
         It should put the value in InputSlot
         """
         self.assertEqual(
-            self.Model._set_option_tray(None, "Test Tray"), {"InputSlot": "Test Tray"}
+            self.Model._set_option_input_tray(None, "Test Tray"),
+            {"InputSlot": "Test Tray"},
         )
-        self.assertEqual(self.Model._set_option_tray(None, False), {})
+        self.assertEqual(self.Model._set_option_input_tray(None, False), {})
 
     def test_option_noops(self):
         """
@@ -77,7 +78,9 @@ class TestPrintingPrinter(TransactionCase):
             self.Model.print_options(report, doc_format="raw", copies=2),
             {"raw": "True", "copies": "2"},
         )
-        self.assertTrue("InputSlot" in self.Model.print_options(report, tray="Test"))
+        self.assertTrue(
+            "InputSlot" in self.Model.print_options(report, input_tray="Test")
+        )
 
     @mock.patch("%s.cups" % server_model)
     def test_print_report(self, cups):

--- a/base_report_to_printer/tests/test_printing_printer_tray.py
+++ b/base_report_to_printer/tests/test_printing_printer_tray.py
@@ -30,6 +30,20 @@ ppd_input_slot_body = """
 ppd_input_slot_footer = """
 *CloseUI: *InputSlot
 """
+ppd_output_slot_header = """
+*OpenUI *OutputBin/Output Tray: PickOne
+*OrderDependency: 40 AnySetup *OutputBin
+*DefaultOutputBin: Default
+*OutputBin Default/Default: "
+    << /OutputType (Default) >> setpagedevice"
+"""
+ppd_output_slot_body = """
+*OutputBin {name}/{text}: "
+    << /OutputType (Bin{nb}) >> setpagedevice"
+"""
+ppd_output_slot_footer = """
+*CloseUI: *OutputBin
+"""
 
 
 class TestPrintingPrinter(TransactionCase):
@@ -57,28 +71,38 @@ class TestPrintingPrinter(TransactionCase):
             "printer_id": self.printer.id,
         }
 
-    def new_tray(self, vals=None):
+    def new_tray(self, tray_type="input", vals=None):
         values = self.tray_vals
         if vals is not None:
             values.update(vals)
-        return self.env["printing.tray"].create(values)
+        return self.env["printing.tray." + tray_type].create(values)
 
-    def build_ppd(self, input_slots=None):
+    def build_ppd(self, trays=None):
         """
         Builds a fake PPD file declaring defined input slots
         """
         ppd_contents = ppd_header
         ppd_contents += ppd_input_slot_header
-        if input_slots is not None:
-            for input_slot in input_slots:
+        if trays is not None:
+            for slot in trays:
                 ppd_contents += ppd_input_slot_body.format(
-                    name=input_slot["name"], text=input_slot["text"]
+                    name=slot["name"],
+                    text=slot["text"],
                 )
         ppd_contents += ppd_input_slot_footer
+        ppd_contents += ppd_output_slot_header
+        if trays is not None:
+            for slot in trays:
+                ppd_contents += ppd_output_slot_body.format(
+                    name=slot["name"],
+                    text=slot["text"],
+                    nb=slot["text"][-1],
+                )
+        ppd_contents += ppd_output_slot_footer
 
         return ppd_contents
 
-    def mock_cups_ppd(self, cups, file_name=None, input_slots=None):
+    def mock_cups_ppd(self, cups, file_name=None, trays=None):
         """
         Create a fake PPD file (if needed), then mock the getPPD3 method
         return value to give that file
@@ -87,7 +111,7 @@ class TestPrintingPrinter(TransactionCase):
             fd, file_name = tempfile.mkstemp()
 
         if file_name:
-            ppd_contents = self.build_ppd(input_slots=input_slots)
+            ppd_contents = self.build_ppd(trays=trays)
             with open(file_name, "w") as fp:
                 fp.write(ppd_contents)
 
@@ -96,7 +120,7 @@ class TestPrintingPrinter(TransactionCase):
             self.printer.system_name: {
                 "printer-info": "info",
                 "printer-uri-supported": "uri",
-            }
+            },
         }
 
     @mock.patch("%s.cups" % server_model)
@@ -122,7 +146,8 @@ class TestPrintingPrinter(TransactionCase):
         cups_printer = connection.getPrinters()[self.printer.system_name]
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
-        self.assertFalse("tray_ids" in vals)
+        self.assertFalse("input_tray_ids" in vals)
+        self.assertFalse("output_tray_ids" in vals)
 
     @mock.patch("%s.cups" % server_model)
     def test_prepare_update_from_cups_empty_ppd(self, cups):
@@ -140,7 +165,8 @@ class TestPrintingPrinter(TransactionCase):
         cups_printer = connection.getPrinters()[self.printer.system_name]
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
-        self.assertFalse("tray_ids" in vals)
+        self.assertFalse("input_tray_ids" in vals)
+        self.assertFalse("output_tray_ids" in vals)
 
     @mock.patch("%s.cups" % server_model)
     @mock.patch("os.unlink")
@@ -177,8 +203,30 @@ class TestPrintingPrinter(TransactionCase):
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
         self.assertEqual(
-            vals["tray_ids"],
-            [(0, 0, {"name": "Auto (Default)", "system_name": "Auto"})],
+            vals["input_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Auto (Default)",
+                        "system_name": "Auto",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(
+            vals["output_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Default",
+                        "system_name": "Default",
+                    },
+                )
+            ],
         )
 
     @mock.patch("%s.cups" % server_model)
@@ -193,8 +241,30 @@ class TestPrintingPrinter(TransactionCase):
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
         self.assertEqual(
-            vals["tray_ids"],
-            [(0, 0, {"name": "Auto (Default)", "system_name": "Auto"})],
+            vals["input_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Auto (Default)",
+                        "system_name": "Auto",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(
+            vals["output_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Default",
+                        "system_name": "Default",
+                    },
+                )
+            ],
         )
 
     @mock.patch("%s.cups" % server_model)
@@ -202,17 +272,57 @@ class TestPrintingPrinter(TransactionCase):
         """
         Check the return value when adding multiple trays at once
         """
-        self.mock_cups_ppd(cups, input_slots=[{"name": "Tray1", "text": "Tray 1"}])
+        self.mock_cups_ppd(
+            cups,
+            trays=[
+                {"name": "Tray1", "text": "Tray 1"},
+            ],
+        )
 
         connection = cups.Connection()
         cups_printer = connection.getPrinters()[self.printer.system_name]
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
         self.assertItemsEqual(
-            vals["tray_ids"],
+            vals["input_tray_ids"],
             [
-                (0, 0, {"name": "Auto (Default)", "system_name": "Auto"}),
-                (0, 0, {"name": "Tray 1", "system_name": "Tray1"}),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Auto (Default)",
+                        "system_name": "Auto",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Tray 1",
+                        "system_name": "Tray1",
+                    },
+                ),
+            ],
+        )
+        self.assertItemsEqual(
+            vals["output_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Default",
+                        "system_name": "Default",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Tray 1",
+                        "system_name": "Tray1",
+                    },
+                ),
             ],
         )
 
@@ -222,18 +332,46 @@ class TestPrintingPrinter(TransactionCase):
         Check that calling the method twice doesn't create the trays multiple
         times
         """
-        self.mock_cups_ppd(cups, input_slots=[{"name": "Tray1", "text": "Tray 1"}])
+        self.mock_cups_ppd(
+            cups,
+            trays=[
+                {"name": "Tray1", "text": "Tray 1"},
+            ],
+        )
 
         connection = cups.Connection()
         cups_printer = connection.getPrinters()[self.printer.system_name]
 
         # Create a tray which is in the PPD file
-        self.new_tray({"system_name": "Tray1"})
+        self.new_tray("input", {"system_name": "Tray1"})
+        self.new_tray("output", {"system_name": "Tray1"})
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
         self.assertEqual(
-            vals["tray_ids"],
-            [(0, 0, {"name": "Auto (Default)", "system_name": "Auto"})],
+            vals["input_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Auto (Default)",
+                        "system_name": "Auto",
+                    },
+                )
+            ],
+        )
+        self.assertEqual(
+            vals["output_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Default",
+                        "system_name": "Default",
+                    },
+                )
+            ],
         )
 
     @mock.patch("%s.cups" % server_model)
@@ -247,10 +385,35 @@ class TestPrintingPrinter(TransactionCase):
         cups_printer = connection.getPrinters()[self.printer.system_name]
 
         # Create a tray which is absent from the PPD file
-        tray = self.new_tray()
+        input_tray = self.new_tray()
+        output_tray = self.new_tray("output")
 
         vals = self.printer._prepare_update_from_cups(connection, cups_printer)
         self.assertEqual(
-            vals["tray_ids"],
-            [(0, 0, {"name": "Auto (Default)", "system_name": "Auto"}), (2, tray.id)],
+            vals["input_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Auto (Default)",
+                        "system_name": "Auto",
+                    },
+                ),
+                (2, input_tray.id),
+            ],
+        )
+        self.assertEqual(
+            vals["output_tray_ids"],
+            [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Default",
+                        "system_name": "Default",
+                    },
+                ),
+                (2, output_tray.id),
+            ],
         )

--- a/base_report_to_printer/tests/test_printing_report_xml_action.py
+++ b/base_report_to_printer/tests/test_printing_report_xml_action.py
@@ -50,7 +50,8 @@ class TestPrintingReportXmlAction(TransactionCase):
             {
                 "action": xml_action.action,
                 "printer": xml_action.printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
@@ -60,16 +61,23 @@ class TestPrintingReportXmlAction(TransactionCase):
             {
                 "action": xml_action.action,
                 "printer": xml_action.printer_id,
-                "tray": False,
+                "input_tray": False,
+                "output_tray": False,
             },
         )
 
         self.assertEqual(self.Model.behaviour(), {})
 
     def test_onchange_printer_tray_id_empty(self):
-        action = self.env["printing.report.xml.action"].new({"printer_tray_id": False})
+        action = self.env["printing.report.xml.action"].new(
+            {
+                "printer_input_tray_id": False,
+                "printer_output_tray_id": False,
+            }
+        )
         action.onchange_printer_id()
-        self.assertFalse(action.printer_tray_id)
+        self.assertFalse(action.printer_input_tray_id)
+        self.assertFalse(action.printer_output_tray_id)
 
     def test_onchange_printer_tray_id_not_empty(self):
         server = self.env["printing.server"].create({})
@@ -86,13 +94,29 @@ class TestPrintingReportXmlAction(TransactionCase):
                 "uri": "URI",
             }
         )
-        tray = self.env["printing.tray"].create(
-            {"name": "Tray", "system_name": "TrayName", "printer_id": printer.id}
+        input_tray = self.env["printing.tray.input"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
+        )
+        output_tray = self.env["printing.tray.output"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
         )
 
         action = self.env["printing.report.xml.action"].new(
-            {"printer_tray_id": tray.id}
+            {
+                "printer_input_tray_id": input_tray.id,
+                "printer_output_tray_id": output_tray.id,
+            }
         )
-        self.assertEqual(action.printer_tray_id, tray)
+        self.assertEqual(action.printer_input_tray_id, input_tray)
+        self.assertEqual(action.printer_output_tray_id, output_tray)
         action.onchange_printer_id()
-        self.assertFalse(action.printer_tray_id)
+        self.assertFalse(action.printer_input_tray_id)
+        self.assertFalse(action.printer_output_tray_id)

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -143,7 +143,8 @@ class TestReport(common.HttpCase):
                 document[0],
                 action="server",
                 doc_format="qweb-pdf",
-                tray=False,
+                input_tray=False,
+                output_tray=False,
             )
 
     def test_render_qweb_text_printable(self):
@@ -163,7 +164,8 @@ class TestReport(common.HttpCase):
                 document[0],
                 action="server",
                 doc_format="qweb-text",
-                tray=False,
+                input_tray=False,
+                output_tray=False,
             )
 
     def test_print_document_not_printable(self):

--- a/base_report_to_printer/tests/test_res_users.py
+++ b/base_report_to_printer/tests/test_res_users.py
@@ -24,9 +24,15 @@ class TestResUsers(common.TransactionCase):
         self.assertTrue(self.new_record())
 
     def test_onchange_printer_tray_id_empty(self):
-        user = self.env["res.users"].new({"printer_tray_id": False})
+        user = self.env["res.users"].new(
+            {
+                "printer_input_tray_id": False,
+                "printer_output_tray_id": False,
+            }
+        )
         user.onchange_printing_printer_id()
-        self.assertFalse(user.printer_tray_id)
+        self.assertFalse(user.printer_input_tray_id)
+        self.assertFalse(user.printer_output_tray_id)
 
     def test_onchange_printer_tray_id_not_empty(self):
         server = self.env["printing.server"].create({})
@@ -43,11 +49,29 @@ class TestResUsers(common.TransactionCase):
                 "uri": "URI",
             }
         )
-        tray = self.env["printing.tray"].create(
-            {"name": "Tray", "system_name": "TrayName", "printer_id": printer.id}
+        input_tray = self.env["printing.tray.input"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
+        )
+        output_tray = self.env["printing.tray.output"].create(
+            {
+                "name": "Tray",
+                "system_name": "TrayName",
+                "printer_id": printer.id,
+            }
         )
 
-        user = self.env["res.users"].new({"printer_tray_id": tray.id})
-        self.assertEqual(user.printer_tray_id, tray)
+        user = self.env["res.users"].new(
+            {
+                "printer_input_tray_id": input_tray.id,
+                "printer_output_tray_id": output_tray.id,
+            }
+        )
+        self.assertEqual(user.printer_input_tray_id, input_tray)
+        self.assertEqual(user.printer_output_tray_id, output_tray)
         user.onchange_printing_printer_id()
-        self.assertFalse(user.printer_tray_id)
+        self.assertFalse(user.printer_input_tray_id)
+        self.assertFalse(user.printer_output_tray_id)

--- a/base_report_to_printer/views/ir_actions_report.xml
+++ b/base_report_to_printer/views/ir_actions_report.xml
@@ -10,7 +10,14 @@
                     <group>
                         <field name="property_printing_action_id" />
                         <field name="printing_printer_id" />
-                        <field name="printer_tray_id" />
+                        <field
+                            name="printer_input_tray_id"
+                            invisible="not printing_printer_id"
+                        />
+                        <field
+                            name="printer_output_tray_id"
+                            invisible="not printing_printer_id"
+                        />
                     </group>
                     <separator string="Specific actions per user" />
                     <field name="printing_action_ids" />

--- a/base_report_to_printer/views/printing_printer.xml
+++ b/base_report_to_printer/views/printing_printer.xml
@@ -81,7 +81,15 @@
                         <field name="multi_thread" />
                     </group>
                     <group string="Trays" name="trays">
-                        <field name="tray_ids" nolabel="1" colspan="2">
+                        <field name="input_tray_ids" nolabel="1">
+                            <form>
+                                <group name="name_fields">
+                                    <field name="name" />
+                                    <field name="system_name" />
+                                </group>
+                            </form>
+                        </field>
+                        <field name="output_tray_ids" nolabel="1" colspan="2">
                             <form>
                                 <group name="name_fields">
                                     <field name="name" />

--- a/base_report_to_printer/views/printing_report.xml
+++ b/base_report_to_printer/views/printing_report.xml
@@ -10,7 +10,11 @@
                     <field name="user_id" />
                     <field name="action" />
                     <field name="printer_id" select="1" />
-                    <field name="printer_tray_id" />
+                    <field name="user_id" />
+                    <field name="action" />
+                    <field name="printer_id" select="1" />
+                    <field name="printer_input_tray_id" />
+                    <field name="printer_output_tray_id" />
                 </group>
             </form>
         </field>
@@ -25,7 +29,11 @@
                 <field name="user_id" />
                 <field name="action" />
                 <field name="printer_id" />
-                <field name="printer_tray_id" />
+                <field name="user_id" />
+                <field name="action" />
+                <field name="printer_id" />
+                <field name="printer_input_tray_id" />
+                <field name="printer_output_tray_id" />
             </tree>
         </field>
     </record>

--- a/printer_zpl2/tests/test_test_mode.py
+++ b/printer_zpl2/tests/test_test_mode.py
@@ -1,27 +1,21 @@
 # Copyright (C) 2018 Florent de Labarre (<https://github.com/fmdl>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from unittest.mock import patch
-
-import requests
+import base64
+from unittest.mock import Mock, patch
 
 from odoo.tools import mute_logger
 
 from .common import PrinterZpl2Common
 
 model = "odoo.addons.base_report_to_printer.models.printing_server"
+label_model = "odoo.addons.printer_zpl2.models.printing_label_zpl2"
+PNG_IMAGE = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2L"
+    "eDkAAAAASUVORK5CYII="
+)
 
 
 class TestWizardPrintRecordLabel(PrinterZpl2Common):
-    @classmethod
-    def setUpClass(cls):
-        cls._super_send = requests.Session.send
-        super().setUpClass()
-
-    @classmethod
-    def _request_handler(cls, s, r, /, **kw):
-        """Don't block external requests."""
-        return cls._super_send(s, r, **kw)
-
     def test_get_record(self):
         """Check if return a record"""
         self.label.record_id = 10
@@ -47,8 +41,10 @@ class TestWizardPrintRecordLabel(PrinterZpl2Common):
         self.label.test_labelary_mode = False
         self.assertIs(self.label.labelary_image, False)
 
-    def test_emulation_with_bad_header(self):
+    @patch("%s.requests.post" % label_model)
+    def test_emulation_with_bad_header(self, post):
         """Check if bad header"""
+        post.return_value = Mock(status_code=400)
         self.label.test_labelary_mode = True
         self.label.labelary_width = 80
         self.label.labelary_dpmm = "8dpmm"
@@ -61,6 +57,7 @@ class TestWizardPrintRecordLabel(PrinterZpl2Common):
         # "ERROR: Label height is larger than 15.0 inches"
         with mute_logger("odoo.addons.printer_zpl2.models.printing_label_zpl2"):
             self.assertFalse(self.label.labelary_image)
+        post.assert_called_once()
 
     def test_emulation_with_bad_data_compute(self):
         """Check if bad data compute"""
@@ -74,8 +71,10 @@ class TestWizardPrintRecordLabel(PrinterZpl2Common):
         component.unlink()
         self.assertIs(self.label.labelary_image, False)
 
-    def test_emulation_with_good_data(self):
+    @patch("%s.requests.post" % label_model)
+    def test_emulation_with_good_data(self, post):
         """Check if ok"""
+        post.return_value = Mock(status_code=200, content=PNG_IMAGE)
         self.label.test_labelary_mode = True
         self.label.labelary_width = 80
         self.label.labelary_height = 30
@@ -84,3 +83,4 @@ class TestWizardPrintRecordLabel(PrinterZpl2Common):
             {"name": "ZPL II Label", "label_id": self.label.id, "data": '"good_data"'}
         )
         self.assertTrue(self.label.labelary_image)
+        post.assert_called_once()


### PR DESCRIPTION
This pull request refactors the printer tray handling in the `base_report_to_printer` module to support separate input and output trays, improving flexibility.

### Model and Field Refactoring

* Split the generic `printing.tray` model into two distinct models: `printing.tray.input` and `printing.tray.output`, and updated all related fields in `ir.actions.report`, `printing.printer`, `printing.report.xml.action`, and `res.users` to use these new models for input and output trays. 
* Updated onchange and default behaviour methods to reset and return values for both input and output trays, ensuring correct handling when printer or tray selections change.

### Printer Synchronization and Options

* Modified the printer update logic to separately synchronize input and output trays from CUPS, and added new methods for setting printer options for both tray types.

### Security and Access Control

* Updated security rules to grant appropriate access to the new input and output tray models, including separate permissions for users and managers.

### Tests and Backwards Compatibility

* Refactored tests to use the new input/output tray fields and models, ensuring all behaviour checks are updated and remain valid.

### Miscellaneous

* Updated the module version to `17.0.1.1.2` to reflect these changes.