### PR TITLE
[16.0][IMP] base_report_to_printer: out of connection fallback to client

### DIFF
--- a/base_report_to_label_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_label_printer/tests/test_ir_actions_report.py
@@ -10,7 +10,9 @@ class TestIrActionsReport(TransactionCase):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
-        cls.Model = cls.env["ir.actions.report"]
+        cls.Model = cls.env["ir.actions.report"].with_context(
+            skip_printer_exception=True
+        )
         cls.server = cls.env["printing.server"].create({})
 
     def new_printer(self):

--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -10,18 +10,34 @@ async function cupsReportActionHandler(action, options, env) {
             "print_action_for_report_name",
             [action.report_name]
         );
-        if (print_action && print_action.action === "server") {
+        if (
+            print_action &&
+            print_action.action === "server" &&
+            !print_action.printer_exception
+        ) {
             const result = await orm.call("ir.actions.report", "print_document", [
                 action.id,
                 action.context.active_ids,
                 action.data,
             ]);
             if (result) {
-                env.services.notification.add(env._t("Successfully sent to printer!"));
+                env.services.notification.add(env._t("Successfully sent to printer!"), {
+                    type: "success",
+                });
             } else {
-                env.services.notification.add(env._t("Could not send to printer!"));
+                env.services.notification.add(env._t("Could not send to printer!"), {
+                    type: "danger",
+                });
             }
             return true;
+        }
+        if (print_action.printer_exception) {
+            env.services.notification.add(
+                env._t("The printer couldn't be reached. Downloading document instead"),
+                {
+                    type: "warning",
+                }
+            );
         }
     }
 }

--- a/base_report_to_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_printer/tests/test_ir_actions_report.py
@@ -12,10 +12,12 @@ model = "odoo.addons.base.models.ir_actions_report.IrActionsReport"
 class TestIrActionsReportXml(TransactionCase):
     def setUp(self):
         super(TestIrActionsReportXml, self).setUp()
-        self.Model = self.env["ir.actions.report"]
+        self.Model = self.env["ir.actions.report"].with_context(
+            skip_printer_exception=True
+        )
         self.vals = {}
 
-        self.report = self.env["ir.actions.report"].search([], limit=1)
+        self.report = self.Model.search([], limit=1)
         self.server = self.env["printing.server"].create({})
 
     def new_action(self):
@@ -153,7 +155,7 @@ class TestIrActionsReportXml(TransactionCase):
         self.env.user.printing_action = "client"
         printing_action = self.new_printing_action()
         printing_action.user_id = self.env.user
-        printing_action.report_id = self.env["ir.actions.report"].search(
+        printing_action.report_id = self.Model.search(
             [("id", "!=", report.id)], limit=1
         )
         self.assertEqual(
@@ -213,7 +215,7 @@ class TestIrActionsReportXml(TransactionCase):
         """
         It should return the correct tray
         """
-        report = self.env["ir.actions.report"].search([], limit=1)
+        report = self.Model.search([], limit=1)
         action = self.env["printing.report.xml.action"].create(
             {"user_id": self.env.user.id, "report_id": report.id, "action": "server"}
         )
@@ -266,7 +268,7 @@ class TestIrActionsReportXml(TransactionCase):
         self.assertEqual("Action tray", report.behaviour()["tray"])
 
     def test_onchange_printer_tray_id_empty(self):
-        action = self.env["ir.actions.report"].new({"printer_tray_id": False})
+        action = self.Model.new({"printer_tray_id": False})
         action.onchange_printing_printer_id()
         self.assertFalse(action.printer_tray_id)
 
@@ -289,7 +291,7 @@ class TestIrActionsReportXml(TransactionCase):
             {"name": "Tray", "system_name": "TrayName", "printer_id": printer.id}
         )
 
-        action = self.env["ir.actions.report"].new({"printer_tray_id": tray.id})
+        action = self.Model.new({"printer_tray_id": tray.id})
         self.assertEqual(action.printer_tray_id, tray)
         action.onchange_printing_printer_id()
         self.assertFalse(action.printer_tray_id)

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -11,7 +11,9 @@ from odoo.tests import common
 class TestReport(common.HttpCase):
     def setUp(self):
         super(TestReport, self).setUp()
-        self.Model = self.env["ir.actions.report"]
+        self.Model = self.env["ir.actions.report"].with_context(
+            skip_printer_exception=True
+        )
         self.server = self.env["printing.server"].create({})
         self.report_vals = {
             "name": "Test Report",


### PR DESCRIPTION
fw of #346 

If the CUPS server isn't available the user won't be able to do anything to print the report they need.

At last we can give them the chance to have a fallback behavior downloading the document.

cc @Tecnativa TT47134

please review @sergio-teruel @carlosdauden 