### PR TITLE
[16.0][IMP] base_report_to_printer: avoid printing if printer is not active

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -178,22 +178,25 @@ class PrintingPrinter(models.Model):
     def print_file(self, file_name, report=None, **print_opts):
         """Print a file"""
         self.ensure_one()
-        title = print_opts.pop("title", file_name)
-        connection = self.server_id._open_connection(raise_on_error=True)
-        options = self.print_options(report=report, **print_opts)
+        if self.active:
+            title = print_opts.pop("title", file_name)
+            connection = self.server_id._open_connection(raise_on_error=True)
+            options = self.print_options(report=report, **print_opts)
 
-        _logger.debug(
-            "Sending job to CUPS printer %s on %s with options %s"
-            % (self.system_name, self.server_id.address, options)
-        )
-        connection.printFile(self.system_name, file_name, title, options=options)
-        _logger.info(
-            "Printing job: '{}' on {}".format(file_name, self.server_id.address)
-        )
-        try:
-            os.remove(file_name)
-        except OSError as exc:
-            _logger.warning("Unable to remove temporary file %s: %s", file_name, exc)
+            _logger.debug(
+                "Sending job to CUPS printer %s on %s with options %s"
+                % (self.system_name, self.server_id.address, options)
+            )
+            connection.printFile(self.system_name, file_name, title, options=options)
+            _logger.info(
+                "Printing job: '{}' on {}".format(file_name, self.server_id.address)
+            )
+            try:
+                os.remove(file_name)
+            except OSError as exc:
+                _logger.warning(
+                    "Unable to remove temporary file %s: %s", file_name, exc
+                )
         return True
 
     def set_default(self):


### PR DESCRIPTION
If you print by code on an archived printer, it keeps printing.
With this PR it prints only if the printer is active