### PR TITLE
[17.0][FW] oca-port: forward missing commits from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/base_report_to_printer.json
+++ b/.oca/oca-port/blacklist/base_report_to_printer.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "242": "(auto) Nothing to port from PR #242"
+  }
+}

--- a/base_report_to_printer/i18n/sv.po
+++ b/base_report_to_printer/i18n/sv.po
@@ -921,7 +921,7 @@ msgstr "Guide"
 #: code:addons/base_report_to_printer/wizards/print_attachment_report.py:0
 #, python-format
 msgid "{name} ({copies} copies)"
-msgstr "{namn} ({kopior} kopior)"
+msgstr "{name} ({copies} kopior)"
 
 #~ msgid "Job"
 #~ msgstr "Jobb"

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -4,9 +4,10 @@
 # Copyright (C) 2011 Domsense srl (<http://www.domsense.com>)
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from time import time
 
 from odoo import _, api, exceptions, fields, models
-from odoo.tools.safe_eval import safe_eval, time
+from odoo.tools.safe_eval import safe_eval
 
 REPORT_TYPES = {"qweb-pdf": "pdf", "qweb-text": "text"}
 

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -128,6 +128,7 @@
          <field eval="1" name="perm_read" />
          <field eval="1" name="perm_unlink" />
          <field eval="1" name="perm_write" />
+         <field eval="1" name="perm_create" />
     </record>
     <record id="access_wizard_print_attachment_user" model="ir.model.access">
         <field name="name">Print Attachment User</field>


### PR DESCRIPTION
### This change
- Took this occasion to 
  - fix access right: 
     - Access rights were added in https://github.com/OCA/report-print-send/commit/c7fac1bd4346828bb41012eab00caf86a392c421
     - But the author missed to add create access for the wizard, which results in Access Error when clicking 'Update Printers from CUPS'
  - fix wrong translated term