### PR TITLE
[15.0][IMP] base_report_to_printer: exceptions notifications

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -106,6 +106,13 @@ Guidelines for use:
 When no tray is configured for a report and a user, the
 default tray setup on the CUPS server is used.
 
+Known issues / Roadmap
+======================
+
+- With threaded printing there's no download fallback when the issue isn't detected by
+  the CUPS Odoo backend. To able to do it, we would need to notify the bus or use
+  web_notify for it.
+
 Changelog
 =========
 

--- a/base_report_to_printer/i18n/base_report_to_printer.pot
+++ b/base_report_to_printer/i18n/base_report_to_printer.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-11 16:21+0000\n"
+"PO-Revision-Date: 2024-11-11 16:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -380,6 +382,13 @@ msgid "If checked, this server is useable."
 msgstr ""
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
+#, python-format
+msgid "Issue on"
+msgstr ""
+
+#. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_job_view_form
 msgid "Job"
 msgstr ""
@@ -552,8 +561,11 @@ msgid "Port of the server."
 msgstr ""
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.act_report_xml_view
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.wizard_print_attachment_form
+#, python-format
 msgid "Print"
 msgstr ""
 
@@ -828,7 +840,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
 #, python-format
-msgid "The printer couldn't be reached. Downloading document instead"
+msgid "The report"
 msgstr ""
 
 #. module: base_report_to_printer
@@ -948,6 +960,13 @@ msgstr ""
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__wizard_id
 msgid "Wizard"
+msgstr ""
+
+#. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
+#, python-format
+msgid "couldn't be printed. Click on the button below to download it"
 msgstr ""
 
 #. module: base_report_to_printer

--- a/base_report_to_printer/i18n/es.po
+++ b/base_report_to_printer/i18n/es.po
@@ -1,23 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * base_report_to_printer
+# 	* base_report_to_printer
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-19 03:38+0000\n"
-"PO-Revision-Date: 2023-10-16 19:36+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"POT-Creation-Date: 2024-11-11 16:26+0000\n"
+"PO-Revision-Date: 2024-11-11 17:27+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields.selection,name:base_report_to_printer.selection__printing_job__job_state__aborted
@@ -59,7 +57,8 @@ msgstr "Archivado"
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_printer_view_form
 msgid "Are you sure to want to cancel all jobs of this printer?"
-msgstr "¿Estás seguro que quieres cancelar todos los trabajos de la impresora?"
+msgstr ""
+"¿Estás seguro que quieres cancelar todos los trabajos de la impresora?"
 
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_printer_view_form
@@ -298,7 +297,7 @@ msgstr "Política de cifrado para conectar al servidor. Vacía por defecto."
 #. module: base_report_to_printer
 #: model:ir.model.fields.selection,name:base_report_to_printer.selection__printing_printer__status__error
 msgid "Error"
-msgstr "Error"
+msgstr ""
 
 #. module: base_report_to_printer
 #: model:ir.model.fields.selection,name:base_report_to_printer.selection__printing_job__job_state_reason__compression-error
@@ -314,8 +313,8 @@ msgstr "Error en el documento"
 #: code:addons/base_report_to_printer/models/printing_server.py:0
 #, python-format
 msgid ""
-"Failed to connect to the CUPS server on %(address)s:%(port)s. Check that the "
-"CUPS server is running and that you can reach it from the Odoo server."
+"Failed to connect to the CUPS server on %(address)s:%(port)s. Check that "
+"the CUPS server is running and that you can reach it from the Odoo server."
 msgstr ""
 "Ha fallado la conexión al servidor CUPS en %(address)s:%(port)s. Compruebe "
 "que el servidor CUPS está en funcionamiento y que el servidor de Odoo tiene "
@@ -379,7 +378,7 @@ msgstr "Retenido por que la impresora está desconectada"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,help:base_report_to_printer.field_printing_server__address
@@ -390,6 +389,13 @@ msgstr "Dirección IP o nombre del servidor"
 #: model:ir.model.fields,help:base_report_to_printer.field_printing_server__active
 msgid "If checked, this server is useable."
 msgstr "Si está marcado, el servidor es utilizable."
+
+#. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
+#, python-format
+msgid "Issue on"
+msgstr "Incidencia en"
 
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_job_view_form
@@ -480,7 +486,7 @@ msgstr "Modelo"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_printer__multi_thread
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__multi_thread
 msgid "Multi Thread"
-msgstr ""
+msgstr "Multi Hilo"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_action__name
@@ -515,7 +521,7 @@ msgstr "Sin razón"
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printer_update_wizard
 msgid "Ok"
-msgstr "Ok"
+msgstr ""
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_ir_actions_report__printer_tray_id
@@ -564,8 +570,11 @@ msgid "Port of the server."
 msgstr "Puerto del servidor."
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.act_report_xml_view
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.wizard_print_attachment_form
+#, python-format
 msgid "Print"
 msgstr "Imprimir"
 
@@ -657,7 +666,7 @@ msgstr "Lista de impresoras"
 #: model:ir.ui.menu,name:base_report_to_printer.printing_menu
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.view_users_form
 msgid "Printing"
-msgstr "Impresión"
+msgstr "Imprimiendo"
 
 #. module: base_report_to_printer
 #: model:res.groups,name:base_report_to_printer.printing_group_manager
@@ -727,7 +736,7 @@ msgstr "Informe"
 #. module: base_report_to_printer
 #: model:ir.model,name:base_report_to_printer.model_ir_actions_report
 msgid "Report Action"
-msgstr "Informar Acción"
+msgstr "Acción de informe"
 
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_report_xml_action_view_form
@@ -840,8 +849,8 @@ msgstr "El ID del trabajo debe ser único por servidor !"
 #. openerp-web
 #: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
 #, python-format
-msgid "The printer couldn't be reached. Downloading document instead"
-msgstr ""
+msgid "The report"
+msgstr "El informe"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,help:base_report_to_printer.field_ir_actions_report__printing_action_ids
@@ -851,7 +860,8 @@ msgstr "Este campo permite configurar acción e impresora a nivel de usuario"
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printer_update_wizard
 msgid ""
-"This process will create all missing printers from the current CUPS server.\""
+"This process will create all missing printers from the current CUPS server."
+"\""
 msgstr ""
 "Este proceso creará todas las impresoras que falten desde el servidor CUPS "
 "actual"
@@ -890,7 +900,7 @@ msgstr "Tipo"
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_printer__uri
 msgid "URI"
-msgstr "URI"
+msgstr ""
 
 #. module: base_report_to_printer
 #: model:ir.model.fields.selection,name:base_report_to_printer.selection__printing_printer__status__unavailable
@@ -964,36 +974,14 @@ msgid "Wizard"
 msgstr "Asistente"
 
 #. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/js/qweb_action_manager.esm.js:0
+#, python-format
+msgid "couldn't be printed. Click on the button below to download it"
+msgstr "no se ha podido imprimir. Pulsar en el botón para descargarlo"
+
+#. module: base_report_to_printer
 #: code:addons/base_report_to_printer/wizards/print_attachment_report.py:0
 #, python-format
 msgid "{name} ({copies} copies)"
 msgstr "{name} ({copies} copies) :{name} ({copies} copias)"
-
-#, python-format
-#~ msgid "Document sent to the printer %s"
-#~ msgstr "Documento enviado a la impresora %s"
-
-#, python-format
-#~ msgid "Error when sending the document to the printer "
-#~ msgstr "Error enviando el documento a la impresora "
-
-#, python-format
-#~ msgid ""
-#~ "Failed to connect to the CUPS server on %s:%s. Check that the CUPS server "
-#~ "is running and that you can reach it from the Odoo server."
-#~ msgstr ""
-#~ "Ha fallado la conexión al servidor CUPS %s:%s. Comprueba que el servidor "
-#~ "CUPS está funcionando y que el servidor de Odoo puede comunicarse con él."
-
-#~ msgid ""
-#~ "This process will create all missing printers from the current CUPS "
-#~ "server."
-#~ msgstr ""
-#~ "Este proceso creará las impresoras no configurada del servidor CUPS "
-#~ "actual."
-
-#~ msgid "or"
-#~ msgstr "o"
-
-#~ msgid "ir.actions.report"
-#~ msgstr "ir.actions.report"

--- a/base_report_to_printer/readme/ROADMAP.rst
+++ b/base_report_to_printer/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+- With threaded printing there's no download fallback when the issue isn't detected by
+  the CUPS Odoo backend. To able to do it, we would need to notify the bus or use
+  web_notify for it.

--- a/base_report_to_printer/static/description/index.html
+++ b/base_report_to_printer/static/description/index.html
@@ -396,16 +396,17 @@ preprinted paper such as payment slip.</p>
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
 <li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
-<li><a class="reference internal" href="#changelog" id="toc-entry-4">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-5">13.0.1.0.0 (2019-09-30)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-6">12.0.1.0.0 (2018-02-04)</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-6">13.0.1.0.0 (2019-09-30)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-7">12.0.1.0.0 (2018-02-04)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-7">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-8">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-9">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-10">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-8">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-9">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-10">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-11">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-12">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -456,23 +457,31 @@ change these in <em>Settings &gt; Printing &gt; Reports</em> in
 <p>When no tray is configured for a report and a user, the
 default tray setup on the CUPS server is used.</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>With threaded printing there’s no download fallback when the issue isn’t detected by
+the CUPS Odoo backend. To able to do it, we would need to notify the bus or use
+web_notify for it.</li>
+</ul>
+</div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#toc-entry-4">Changelog</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Changelog</a></h1>
 <div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-5">13.0.1.0.0 (2019-09-30)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">13.0.1.0.0 (2019-09-30)</a></h2>
 <ul class="simple">
 <li>[RELEASE] Port from V12.</li>
 </ul>
 </div>
 <div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-6">12.0.1.0.0 (2018-02-04)</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">12.0.1.0.0 (2018-02-04)</a></h2>
 <ul class="simple">
 <li>[RELEASE] Port from V11.</li>
 </ul>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-7">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-8">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/report-print-send/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -480,9 +489,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-8">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-9">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-9">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Authors</a></h2>
 <ul class="simple">
 <li>Agile Business Group &amp; Domsense</li>
 <li>Pegueroles SCP</li>
@@ -493,7 +502,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-10">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Contributors</a></h2>
 <ul class="simple">
 <li>Ferran Pegueroles &lt;<a class="reference external" href="mailto:ferran&#64;pegueroles.com">ferran&#64;pegueroles.com</a>&gt;</li>
 <li>Albert Cervera i Areny &lt;<a class="reference external" href="mailto:albert&#64;nan-tic.com">albert&#64;nan-tic.com</a>&gt;</li>
@@ -518,7 +527,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
Better handling of exceptions feedback. A notification will show up with the issued printer and report and a button for the user to download the report as a fallback to the failure.

![Peek 11-11-2024 17-31](https://github.com/user-attachments/assets/20ac89a1-00da-469c-99bb-6b7905d81961)


cc @Tecnativa TT51628

please review @sergio-teruel @carlosdauden 