### PR TITLE
[FIX][15.0] base_report_to_printer: Fix access error on product label

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -166,9 +166,10 @@ class IrActionsReport(models.Model):
         if not printer:
             raise exceptions.UserError(_("No printer configured to print this report."))
         if self.print_report_name:
+            model = (data or {}).get("active_model", self.model)
             report_file_names = [
                 safe_eval(self.print_report_name, {"object": obj, "time": time})
-                for obj in self.env[self.model].browse(record_ids)
+                for obj in self.env[model].browse(record_ids)
             ]
             title = " ".join(report_file_names)
             if len(title) > 80:


### PR DESCRIPTION
When printing a product label using the button `Print Label` on the form view for `product.product` the record ID is used on the model defined on the report. The reports are usually defined on `product.template` [1] which causes that the `product.product` ID is used on `product.template` causes an access error in best case or the title of different products to be used.

`active_model` in data is set due to [2] of the wizard.

This seems to be the bug for all versions and this might also be the case for the issue #350 

[1] https://github.com/OCA/OCB/blob/15.0/addons/product/report/product_reports.xml
[2] https://github.com/OCA/OCB/blob/15.0/addons/product/wizard/product_label_layout.py#L60