### PR TITLE
[IMP][16.0] remote_report_to_printer and base_report_to_printer: fix colsapn and keyerro translation

### DIFF
--- a/base_report_to_printer/i18n/tr.po
+++ b/base_report_to_printer/i18n/tr.po
@@ -985,4 +985,4 @@ msgstr "yazdırılamadı. İndirmek için aşağıdaki butona tıklayın"
 #: code:addons/base_report_to_printer/wizards/print_attachment_report.py:0
 #, python-format
 msgid "{name} ({copies} copies)"
-msgstr "{isim} ({kopyalar} kopyalar)"
+msgstr "{name} ({copies} kopyalar)"

--- a/remote_report_to_printer/views/printing_printer.xml
+++ b/remote_report_to_printer/views/printing_printer.xml
@@ -16,6 +16,7 @@
                         name="printer_remote_ids"
                         readonly="1"
                         nolabel="1"
+                        colspan="2"
                         context="{'tree_view_ref':'remote_report_to_printer.res_remote_printer_remote_tree'}"
                     />
                 </group>


### PR DESCRIPTION
fix colspan (remote_report_to_printer)
fix keyerror in .po (base_report_to_printer)


@etobella 