### PR TITLE
[14.0][IMP] Prioritize User Preferences Over Report Settings for Printing

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -86,8 +86,8 @@ class IrActionsReport(models.Model):
         self.ensure_one()
         printing_act_obj = self.env["printing.report.xml.action"]
 
-        result = self._get_user_default_print_behaviour()
-        result.update(self._get_report_default_print_behaviour())
+        result = self._get_report_default_print_behaviour()
+        result.update(self._get_user_default_print_behaviour())
 
         # Retrieve report-user specific values
         print_action = printing_act_obj.search(


### PR DESCRIPTION
When printing reports, user preferences were previously overridden by report settings. This commit inverts the priority, ensuring that user preferences take precedence over report settings, providing a more intuitive behavior.