### PR TITLE
[15.0][IMP] base_report_to_printer: Add fast printer selector

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -89,6 +89,9 @@ directive to "none" (or some other list of values which does not include
 "job-name") , and reload the server. See `cupsd.conf(5)
 <https://www.cups.org/doc/man-cupsd.conf.html>` for details.
 
+If you want to see the button in the top bar to set the user's printer, you need
+to have the "Show printer button on navbar" group.
+
 Usage
 =====
 
@@ -105,6 +108,9 @@ Guidelines for use:
 
 When no tray is configured for a report and a user, the
 default tray setup on the CUPS server is used.
+
+The users are able to change their default printer by using the button with the
+printer icon set on the navbar.
 
 Known issues / Roadmap
 ======================
@@ -172,6 +178,7 @@ Contributors
 
   * Sergio Teruel
   * David Vidal
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_report_to_printer/__manifest__.py
+++ b/base_report_to_printer/__manifest__.py
@@ -27,10 +27,15 @@
         "views/ir_actions_report.xml",
         "wizards/print_attachment_report.xml",
         "wizards/printing_printer_update_wizard_view.xml",
+        "wizards/user_dafault_printer_selector_views.xml",
     ],
     "assets": {
         "web.assets_backend": [
             "/base_report_to_printer/static/src/js/qweb_action_manager.esm.js",
+            "/base_report_to_printer/static/src/js/systray_printer_selector.esm.js",
+        ],
+        "web.assets_qweb": [
+            "/base_report_to_printer/static/src/xml/systray_printer_selector.xml",
         ],
     },
     "installable": True,

--- a/base_report_to_printer/i18n/base_report_to_printer.pot
+++ b/base_report_to_printer/i18n/base_report_to_printer.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-03 07:12+0000\n"
+"PO-Revision-Date: 2025-04-03 07:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -98,6 +100,7 @@ msgstr ""
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printer_update_wizard
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_job_view_form
+#: model_terms:ir.ui.view,arch_db:base_report_to_printer.view_user_default_printer_selector_form
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.wizard_print_attachment_form
 msgid "Cancel"
 msgstr ""
@@ -158,6 +161,11 @@ msgid "Compressed using an unknown algorithm"
 msgstr ""
 
 #. module: base_report_to_printer
+#: model_terms:ir.ui.view,arch_db:base_report_to_printer.view_user_default_printer_selector_form
+msgid "Confirm"
+msgstr ""
+
+#. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__copies
 msgid "Copies"
 msgstr ""
@@ -177,6 +185,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__create_uid
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__create_uid
 msgid "Created by"
@@ -190,6 +199,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__create_date
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__create_date
 msgid "Created on"
@@ -248,6 +258,7 @@ msgstr ""
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_ir_actions_report__printing_printer_id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_res_users__printing_printer_id
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__printing_printer_id
 msgid "Default Printer"
 msgstr ""
 
@@ -269,6 +280,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__display_name
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__display_name
 msgid "Display Name"
@@ -364,6 +376,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__id
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__id
 msgid "ID"
@@ -420,6 +433,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray____last_update
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line____last_update
 msgid "Last Modified on"
@@ -433,6 +447,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__write_uid
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__write_uid
 msgid "Last Updated by"
@@ -446,6 +461,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__write_date
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__write_date
 msgid "Last Updated on"
@@ -748,6 +764,19 @@ msgid "Resources not available to print the job"
 msgstr ""
 
 #. module: base_report_to_printer
+#: model:ir.actions.act_window,name:base_report_to_printer.action_user_default_printer_selector
+msgid "Select printer"
+msgstr ""
+
+#. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/xml/systray_printer_selector.xml:0
+#: code:addons/base_report_to_printer/static/src/xml/systray_printer_selector.xml:0
+#, python-format
+msgid "Select user printer"
+msgstr ""
+
+#. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_job__server_id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_printer__server_id
 msgid "Server"
@@ -784,6 +813,11 @@ msgstr ""
 #. module: base_report_to_printer
 #: model:ir.actions.act_window,name:base_report_to_printer.printing_printer_action
 msgid "Show Printers"
+msgstr ""
+
+#. module: base_report_to_printer
+#: model:res.groups,name:base_report_to_printer.printer_button_group
+msgid "Show printer button on navbar"
 msgstr ""
 
 #. module: base_report_to_printer
@@ -958,6 +992,11 @@ msgstr ""
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__wizard_id
 msgid "Wizard"
+msgstr ""
+
+#. module: base_report_to_printer
+#: model:ir.model,name:base_report_to_printer.model_wiz_user_default_printer_selector
+msgid "Wizard to select user printer"
 msgstr ""
 
 #. module: base_report_to_printer

--- a/base_report_to_printer/i18n/es.po
+++ b/base_report_to_printer/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-11 16:26+0000\n"
-"PO-Revision-Date: 2024-11-12 10:06+0000\n"
+"POT-Creation-Date: 2025-04-03 07:12+0000\n"
+"PO-Revision-Date: 2025-04-03 09:15+0200\n"
 "Last-Translator: David Vidal <david.vidal@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields.selection,name:base_report_to_printer.selection__printing_job__job_state__aborted
@@ -102,6 +102,7 @@ msgstr "Puede ser reiniciado"
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printer_update_wizard
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printing_job_view_form
+#: model_terms:ir.ui.view,arch_db:base_report_to_printer.view_user_default_printer_selector_form
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.wizard_print_attachment_form
 msgid "Cancel"
 msgstr "Cancelar"
@@ -162,6 +163,11 @@ msgid "Compressed using an unknown algorithm"
 msgstr "Comprimido usando un algoritmo desconocido"
 
 #. module: base_report_to_printer
+#: model_terms:ir.ui.view,arch_db:base_report_to_printer.view_user_default_printer_selector_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__copies
 msgid "Copies"
 msgstr "Copias"
@@ -181,6 +187,7 @@ msgstr "¡No se pudo enviar a la impresora!"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__create_uid
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__create_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__create_uid
 msgid "Created by"
@@ -194,6 +201,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__create_date
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__create_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__create_date
 msgid "Created on"
@@ -252,6 +260,7 @@ msgstr "Comportamiento por defecto"
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_ir_actions_report__printing_printer_id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_res_users__printing_printer_id
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__printing_printer_id
 msgid "Default Printer"
 msgstr "Impresora por defecto"
 
@@ -273,6 +282,7 @@ msgstr "Deshabilitado"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__display_name
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__display_name
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__display_name
 msgid "Display Name"
@@ -374,10 +384,11 @@ msgstr "Retenido por que la impresora está desconectada"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__id
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,help:base_report_to_printer.field_printing_server__address
@@ -430,6 +441,7 @@ msgstr "Trabajos imprimidos por esta impresora."
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray____last_update
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment____last_update
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line____last_update
 msgid "Last Modified on"
@@ -443,6 +455,7 @@ msgstr "Última modificación el"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__write_uid
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__write_uid
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__write_uid
 msgid "Last Updated by"
@@ -456,6 +469,7 @@ msgstr "Última actualización por"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_report_xml_action__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_server__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_tray__write_date
+#: model:ir.model.fields,field_description:base_report_to_printer.field_wiz_user_default_printer_selector__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment__write_date
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__write_date
 msgid "Last Updated on"
@@ -520,7 +534,7 @@ msgstr "Sin razón"
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.printer_update_wizard
 msgid "Ok"
-msgstr ""
+msgstr "Vale"
 
 #. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_ir_actions_report__printer_tray_id
@@ -758,6 +772,18 @@ msgid "Resources not available to print the job"
 msgstr "Recursos no disponibles para imprimir este trabajo"
 
 #. module: base_report_to_printer
+#: model:ir.actions.act_window,name:base_report_to_printer.action_user_default_printer_selector
+msgid "Select printer"
+msgstr "Seleccionar impresora"
+
+#. module: base_report_to_printer
+#. openerp-web
+#: code:addons/base_report_to_printer/static/src/xml/systray_printer_selector.xml:0
+#, python-format
+msgid "Select user printer"
+msgstr "Seleccionar impresora del usuario"
+
+#. module: base_report_to_printer
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_job__server_id
 #: model:ir.model.fields,field_description:base_report_to_printer.field_printing_printer__server_id
 msgid "Server"
@@ -795,6 +821,11 @@ msgstr "Marcar como por defecto"
 #: model:ir.actions.act_window,name:base_report_to_printer.printing_printer_action
 msgid "Show Printers"
 msgstr "Mostrar impresoras"
+
+#. module: base_report_to_printer
+#: model:res.groups,name:base_report_to_printer.printer_button_group
+msgid "Show printer button on navbar"
+msgstr "Mostrar botón de impresora en barra superior"
 
 #. module: base_report_to_printer
 #: model_terms:ir.ui.view,arch_db:base_report_to_printer.act_report_xml_view
@@ -970,6 +1001,11 @@ msgstr "Usuarios"
 #: model:ir.model.fields,field_description:base_report_to_printer.field_wizard_print_attachment_line__wizard_id
 msgid "Wizard"
 msgstr "Asistente"
+
+#. module: base_report_to_printer
+#: model:ir.model,name:base_report_to_printer.model_wiz_user_default_printer_selector
+msgid "Wizard to select user printer"
+msgstr "Asistente para seleccionar impresora de usuario"
 
 #. module: base_report_to_printer
 #. openerp-web

--- a/base_report_to_printer/readme/CONFIGURE.rst
+++ b/base_report_to_printer/readme/CONFIGURE.rst
@@ -11,3 +11,6 @@ to change the configuration of your CUPS server and set the JobPrivateValue
 directive to "none" (or some other list of values which does not include
 "job-name") , and reload the server. See `cupsd.conf(5)
 <https://www.cups.org/doc/man-cupsd.conf.html>` for details.
+
+If you want to see the button in the top bar to set the user's printer, you need
+to have the "Show printer button on navbar" group.

--- a/base_report_to_printer/readme/CONTRIBUTORS.rst
+++ b/base_report_to_printer/readme/CONTRIBUTORS.rst
@@ -18,3 +18,4 @@
 
   * Sergio Teruel
   * David Vidal
+  * Carlos Roca

--- a/base_report_to_printer/readme/USAGE.rst
+++ b/base_report_to_printer/readme/USAGE.rst
@@ -11,3 +11,6 @@ Guidelines for use:
 
 When no tray is configured for a report and a user, the
 default tray setup on the CUPS server is used.
+
+The users are able to change their default printer by using the button with the
+printer icon set on the navbar.

--- a/base_report_to_printer/security/ir.model.access.csv
+++ b/base_report_to_printer/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 access_printing_printer_update_wizard,printers update,model_printing_printer_update_wizard,base.group_system,1,1,1,1
+access_wiz_user_default_printer_selector,access_wiz_user_default_printer_selector,model_wiz_user_default_printer_selector,base.group_user,1,1,1,1

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -13,6 +13,10 @@
     <record id="base.group_erp_manager" model="res.groups">
         <field name="implied_ids" eval="[(4, ref('printing_group_manager'))]" />
     </record>
+    <record id="printer_button_group" model="res.groups">
+        <field name="name">Show printer button on navbar</field>
+        <field name="users" eval="[Command.link(ref('base.user_admin'))]" />
+    </record>
     <record id="printing_server_group_manager" model="ir.model.access">
         <field name="name">Printing Server Manager</field>
         <field name="model_id" ref="model_printing_server" />

--- a/base_report_to_printer/static/description/index.html
+++ b/base_report_to_printer/static/description/index.html
@@ -438,6 +438,8 @@ to change the configuration of your CUPS server and set the JobPrivateValue
 directive to “none” (or some other list of values which does not include
 “job-name”) , and reload the server. See <cite>cupsd.conf(5)
 &lt;https://www.cups.org/doc/man-cupsd.conf.html&gt;</cite> for details.</p>
+<p>If you want to see the button in the top bar to set the user’s printer, you need
+to have the “Show printer button on navbar” group.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
@@ -456,6 +458,8 @@ change these in <em>Settings &gt; Printing &gt; Reports</em> in
 </blockquote>
 <p>When no tray is configured for a report and a user, the
 default tray setup on the CUPS server is used.</p>
+<p>The users are able to change their default printer by using the button with the
+printer icon set on the navbar.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h1>
@@ -522,6 +526,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Sergio Teruel</li>
 <li>David Vidal</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>

--- a/base_report_to_printer/static/src/js/systray_printer_selector.esm.js
+++ b/base_report_to_printer/static/src/js/systray_printer_selector.esm.js
@@ -1,0 +1,41 @@
+/* @odoo-module */
+/* Copyright 2025 Tecnativa - Carlos Roca
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
+const {onWillStart} = owl.hooks;
+const {Component} = owl;
+
+export class SelectPrinterMenu extends Component {
+    setup() {
+        this.action = useService("action");
+        this.user = useService("user");
+        onWillStart(async () => {
+            this.isPrinterUser = await this.user.hasGroup(
+                "base_report_to_printer.printer_button_group"
+            );
+        });
+    }
+
+    /**
+     * Go to user init action when clicking it
+     * @private
+     */
+    onClickSelectPrinter() {
+        this.action.doAction(
+            "base_report_to_printer.action_user_default_printer_selector"
+        );
+    }
+}
+
+SelectPrinterMenu.template = "base_report_to_printer.PrinterSelectorButton";
+
+export const systrayPrinterSelector = {
+    Component: SelectPrinterMenu,
+};
+
+registry
+    .category("systray")
+    .add("base_report_to_printer.printer_selector_button", systrayPrinterSelector, {
+        sequence: 100,
+    });

--- a/base_report_to_printer/static/src/xml/systray_printer_selector.xml
+++ b/base_report_to_printer/static/src/xml/systray_printer_selector.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="base_report_to_printer.PrinterSelectorButton" owl="1">
+        <div class="div_printer_selector">
+            <a
+                class=""
+                name="printer_selector"
+                title="Select user printer"
+                href="#"
+                role="button"
+                t-on-click="onClickSelectPrinter"
+                t-if="isPrinterUser"
+            >
+                <i
+                    class="fa fa-lg fa-print"
+                    role="img"
+                    aria-label="Select user printer"
+                />
+            </a>
+        </div>
+    </t>
+</templates>

--- a/base_report_to_printer/wizards/__init__.py
+++ b/base_report_to_printer/wizards/__init__.py
@@ -1,2 +1,3 @@
 from . import print_attachment_report
 from . import printing_printer_update_wizard
+from . import user_default_printer_selector

--- a/base_report_to_printer/wizards/user_dafault_printer_selector_views.xml
+++ b/base_report_to_printer/wizards/user_dafault_printer_selector_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_user_default_printer_selector_form" model="ir.ui.view">
+        <field name="name">wiz.user.default.printer.selector.form</field>
+        <field name="model">wiz.user.default.printer.selector</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="printing_printer_id" widget="selection_badge" />
+                <footer>
+                    <button
+                        type="object"
+                        name="action_confirm"
+                        string="Confirm"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_user_default_printer_selector">
+        <field name="name">Select printer</field>
+        <field name="res_model">wiz.user.default.printer.selector</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>

--- a/base_report_to_printer/wizards/user_default_printer_selector.py
+++ b/base_report_to_printer/wizards/user_default_printer_selector.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class WizStockBarcodesUserPrinterSelector(models.TransientModel):
+    _name = "wiz.user.default.printer.selector"
+    _description = "Wizard to select user printer"
+
+    printing_printer_id = fields.Many2one(
+        comodel_name="printing.printer",
+        string="Default Printer",
+        default=lambda self: self.env.user.printing_printer_id,
+    )
+
+    def action_confirm(self):
+        self.ensure_one()
+        self.env.user.printing_printer_id = self.printing_printer_id


### PR DESCRIPTION
Sometimes, a user may be working from different devices (if they're an operator) or moving around the company with a tablet and needs to print using the nearest printer, without losing focus on their current task.

With these changes, we allow them to quickly switch printers without having to access their user profile.

Here you have an example of how it works:
![printer_selector](https://github.com/user-attachments/assets/1f810d76-9ec0-48f0-bfc0-3f76be326c74)

cc @Tecnativa TT55759

ping @sergio-teruel @carlosdauden 