### PR TITLE
[FIX] base_report_to_label_printer: _get_user_default_printer is deprecated

### DIFF
--- a/base_report_to_label_printer/models/ir_actions_report.py
+++ b/base_report_to_label_printer/models/ir_actions_report.py
@@ -9,7 +9,9 @@ class IrActionsReport(models.Model):
 
     label = fields.Boolean(string="Report is a Label")
 
-    def _get_user_default_printer(self, user):
+    def _get_user_default_print_behaviour(self):
+        result = super()._get_user_default_print_behaviour()
         if self.label:
-            return user.default_label_printer_id
-        return super()._get_user_default_printer(user)
+            user = self.env.user
+            result["printer"] = user.default_label_printer_id or result["printer"]
+        return result


### PR DESCRIPTION
The `_get_user_default_printer` method has been removed since `Odoo 15.0`.
This PR refactors the custom logic that previously relied on `_get_user_default_printer` by adapting it to the `_get_user_default_print_behaviour`.