### PR TITLE
[15.0][FIX] base_report_to_printer: Available printers when CUPS can't be connected

### DIFF
--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -98,45 +98,50 @@ class PrintingServer(models.Model):
 
         res = True
         for server in servers.with_context(active_test=False):
-            connection = server._open_connection(raise_on_error=raise_on_error)
-            if not connection:
-                server.printer_ids.write({"status": "server-error"})
-                res = False
-                continue
-
-            # Update Printers
-            printers = connection.getPrinters()
-            existing_printers = {
-                printer.system_name: printer for printer in server.printer_ids
-            }
             updated_printers = []
-            for name, printer_info in printers.items():
-                printer = self.env["printing.printer"]
-                if name in existing_printers:
-                    printer = existing_printers[name]
+            try:
+                connection = server._open_connection(raise_on_error=raise_on_error)
+                if not connection:
+                    server.printer_ids.write({"status": "server-error"})
+                    res = False
+                    continue
 
-                printer_values = printer._prepare_update_from_cups(
-                    connection, printer_info
+                # Update Printers
+                printers = connection.getPrinters()
+                existing_printers = {
+                    printer.system_name: printer for printer in server.printer_ids
+                }
+                for name, printer_info in printers.items():
+                    printer = self.env["printing.printer"]
+                    if name in existing_printers:
+                        printer = existing_printers[name]
+
+                    printer_values = printer._prepare_update_from_cups(
+                        connection, printer_info
+                    )
+                    if server != printer.server_id:
+                        printer_values["server_id"] = server.id
+
+                    updated_printers.append(name)
+                    # We want to keep any existing customized name over existing printer
+                    # We want also to rely in the system name as a fallback to avoid
+                    # empty names.
+                    if not printer_values.get("name") and not printer.name:
+                        printer_values["name"] = name
+                    if not printer:
+                        printer_values["system_name"] = name
+                        printer.create(printer_values)
+                    elif printer_values:
+                        printer.write(printer_values)
+                # Set printers not found as unavailable
+                server.printer_ids.filtered(
+                    lambda record: record.system_name not in updated_printers
+                ).write({"status": "unavailable"})
+            except Exception:
+                _logger.warning(
+                    _("Connection failed with printing server %s", server.name)
                 )
-                if server != printer.server_id:
-                    printer_values["server_id"] = server.id
-
-                updated_printers.append(name)
-                # We want to keep any existing customized name over existing printer
-                # We want also to rely in the system name as a fallback to avoid
-                # empty names.
-                if not printer_values.get("name") and not printer.name:
-                    printer_values["name"] = name
-                if not printer:
-                    printer_values["system_name"] = name
-                    printer.create(printer_values)
-                elif printer_values:
-                    printer.write(printer_values)
-
-            # Set printers not found as unavailable
-            server.printer_ids.filtered(
-                lambda record: record.system_name not in updated_printers
-            ).write({"status": "unavailable"})
+                server.printer_ids.write({"status": "server-error"})
 
         return res
 

--- a/base_report_to_printer/tests/test_printing_printer_wizard.py
+++ b/base_report_to_printer/tests/test_printing_printer_wizard.py
@@ -3,7 +3,6 @@
 
 from unittest import mock
 
-from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 
 model = "odoo.addons.base_report_to_printer.models.printing_server"
@@ -53,11 +52,17 @@ class TestPrintingPrinterWizard(TransactionCase):
         cups.Connection().getPrinters.assert_called_once_with()
 
     @mock.patch("%s.cups" % model)
-    def test_action_ok_raises_warning_on_error(self, cups):
-        """It should raise Warning on any error"""
+    def test_action_ok_unavailable_printers_on_error(self, cups):
+        """It should set printers to unavailable on any error"""
         cups.Connection.side_effect = StopTest
-        with self.assertRaises(UserError):
-            self.Model.action_ok()
+        vals = self._record_vals()
+        vals["status"] = "available"
+        self.env["printing.printer"].create(vals)
+        self.Model.action_ok()
+        printer = self.env["printing.printer"].search(
+            [("system_name", "=", "sys_name")]
+        )
+        self.assertEqual(printer.status, "server-error")
 
     @mock.patch("%s.cups" % model)
     def test_action_ok_creates_new_printer(self, cups):


### PR DESCRIPTION
The printers of a CUPS are still available even if no connection to the server can be established.

With this change we ensure that the status of the printers becomes unavailable.

@Tecnativa