### PR TITLE
[18.0][FIX] base_report_to_label_printer: Fix self access rights

### DIFF
--- a/base_report_to_label_printer/models/res_users.py
+++ b/base_report_to_label_printer/models/res_users.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Raumschmiede GmbH - Christopher Hansen (<https://www.raumschmiede.de>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResUsers(models.Model):
@@ -11,8 +11,10 @@ class ResUsers(models.Model):
         comodel_name="printing.printer", string="Default Label Printer"
     )
 
-    @api.model
-    def _register_hook(self):
-        super()._register_hook()
-        self.SELF_WRITEABLE_FIELDS.extend(["default_label_printer_id"])
-        self.SELF_READABLE_FIELDS.extend(["default_label_printer_id"])
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ["default_label_printer_id"]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ["default_label_printer_id"]


### PR DESCRIPTION
This might have been ported from `14.0` to `18.0`
`SELF_READABLE_FIELDS` and `SELF_WRITEABLE_FIELDS` aren't lists anymore, but property methods.
This was preventing users to open their own profile.