### PR TITLE
[18.0][FIX] base_report_to_printer: removal of messageIsHtml

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # Copyright 2024 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 import threading
 from time import time
 
@@ -12,6 +13,8 @@ from odoo import _, api, exceptions, fields, models, registry
 from odoo.tools.safe_eval import safe_eval
 
 REPORT_TYPES = {"qweb-pdf": "pdf", "qweb-text": "text"}
+
+_logger = logging.getLogger(__name__)
 
 
 class IrActionsReport(models.Model):
@@ -118,6 +121,8 @@ class IrActionsReport(models.Model):
                     "unavailable",
                 ]
             except Exception:
+                if not self.env.context.get("skip_printer_exception"):
+                    _logger.critical("Failed open connection", exc_info=True)
                 printer_exception = True
             if printer_exception and not self.env.context.get("skip_printer_exception"):
                 result["printer_exception"] = True
@@ -141,6 +146,8 @@ class IrActionsReport(models.Model):
             try:
                 return self.print_document(record_ids, data=data)
             except Exception:
+                if not self.env.context.get("skip_printer_exception"):
+                    _logger.critical("Failed open connection", exc_info=True)
                 return
 
     def print_document_threaded(self, report_id, record_ids, data):

--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -1,5 +1,5 @@
-import {markup} from "@odoo/owl";
 import {_t} from "@web/core/l10n/translation";
+import {markup} from "@odoo/owl";
 import {registry} from "@web/core/registry";
 
 async function cupsReportActionHandler(action, options, env) {
@@ -51,7 +51,6 @@ async function cupsReportActionHandler(action, options, env) {
                     title: `${terms.issue_on} ${print_action.printer_name}`,
                     type: "warning",
                     sticky: true,
-                    messageIsHtml: true,
                     buttons: [
                         {
                             name: _t("Print"),


### PR DESCRIPTION
This does not appear to exist and this results in a client side error sometimes.

Also cleared the eslint warning regarding ordering of imports.

I've also ensured that exceptions are logged, because that would've actually helped me with my real problem tonight.