### PR TITLE
[IMP] base_report_to_printer: Add a hook to get default printer for user

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -63,12 +63,16 @@ class IrActionsReport(models.Model):
             serializable_result["action"] = "client"
         return serializable_result
 
+    def _get_user_default_printer(self, user):
+        return user.printing_printer_id
+
     def _get_user_default_print_behaviour(self):
         printer_obj = self.env["printing.printer"]
         user = self.env.user
+        printer = self._get_user_default_printer(user)
         return dict(
             action=user.printing_action or "client",
-            printer=user.printing_printer_id or printer_obj.get_default(),
+            printer=printer or printer_obj.get_default(),
             tray=str(user.printer_tray_id.system_name)
             if user.printer_tray_id
             else False,


### PR DESCRIPTION
Ported from v14 (From https://github.com/OCA/report-print-send/pull/313). Impossible to get back the original code as mixed in one commit with another module.