### PR TITLE
[18.0] [FIX] printing_auto_base: error should be readonly and not copied

### DIFF
--- a/printing_auto_base/models/printing_auto_mixin.py
+++ b/printing_auto_base/models/printing_auto_mixin.py
@@ -15,7 +15,7 @@ class PrintingAutoMixin(models.AbstractModel):
     auto_printing_ids = fields.Many2many(
         "printing.auto", string="Auto Printing Configuration"
     )
-    printing_auto_error = fields.Text("Printing error")
+    printing_auto_error = fields.Text("Printing error", readonly=True, copy=False)
 
     def _on_printing_auto_start(self):
         self.write({"printing_auto_error": False})


### PR DESCRIPTION

https://github.com/user-attachments/assets/472ab16a-dc01-4d8d-b0ab-a6980d6f35d3

