### PR TITLE
[16.0][IMP] base_report_to_printer: Add company rules for printers and servers

### DIFF
--- a/base_report_to_printer/models/printing_server.py
+++ b/base_report_to_printer/models/printing_server.py
@@ -43,6 +43,9 @@ class PrintingServer(models.Model):
         help="List of printers available on this server.",
     )
     multi_thread = fields.Boolean()
+    company_ids = fields.Many2many(
+        comodel_name="res.company",
+    )
 
     def _open_connection(self, raise_on_error=False):
         self.ensure_one()

--- a/base_report_to_printer/security/security.xml
+++ b/base_report_to_printer/security/security.xml
@@ -148,4 +148,25 @@
         <field eval="1" name="perm_write" />
         <field eval="1" name="perm_create" />
     </record>
+    <record id="printing_server_company_rule" model="ir.rule">
+        <field name="name">Printing Server multi-company</field>
+        <field name="model_id" ref="model_printing_server" />
+        <field name="domain_force">
+            ["|", ("company_ids", "=", False), ("company_ids", "in", company_ids)]
+        </field>
+    </record>
+    <record id="printer_company_rule" model="ir.rule">
+        <field name="name">Printer multi-company</field>
+        <field name="model_id" ref="model_printing_printer" />
+        <field name="domain_force">
+            ["|", ("server_id.company_ids", "=", False), ("server_id.company_ids", "in", company_ids)]
+        </field>
+    </record>
+    <record id="printing_job_company_rule" model="ir.rule">
+        <field name="name">Printing Job multi-company</field>
+        <field name="model_id" ref="model_printing_job" />
+        <field name="domain_force">
+            ["|", ("server_id.company_ids", "=", False), ("server_id.company_ids", "in", company_ids)]
+        </field>
+    </record>
 </odoo>

--- a/base_report_to_printer/views/printing_server.xml
+++ b/base_report_to_printer/views/printing_server.xml
@@ -24,8 +24,17 @@
                         </h1>
                     </div>
                     <group>
-                        <field name="address" />
-                        <field name="port" />
+                        <group>
+                            <field name="address" />
+                            <field name="port" />
+                        </group>
+                        <group>
+                            <field
+                                name="company_ids"
+                                widget="many2many_tags"
+                                groups="base.group_multi_company"
+                            />
+                        </group>
                     </group>
                     <group>
                         <field name="user" />


### PR DESCRIPTION
Context:
- I have a printer server located at "My Company" in New York, also have "Another company" in Brooklyn, I don't want to be sent to print from Brooklyn to New York printer

Before this PR:
- All printers, jobs, servers available for all companies.

After this PR:
- If the company is specified on the printer server, only related printers are available for the company.

Note: Previously, this PR was closed due to expiration, and a new similar one was created (https://github.com/OCA/report-print-send/pull/368)