### PR TITLE
[18.0][IMP] printing_auto_base: use MagicMock for print_document test

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -34,7 +34,7 @@ class IrActionsReport(models.Model):
         comodel_name="printing.report.xml.action",
         inverse_name="report_id",
         string="Actions",
-        help="This field allows configuring action and printer on a per " "user basis",
+        help="This field allows configuring action and printer on a per user basis",
     )
 
     @api.onchange("printing_printer_id")

--- a/printing_auto_base/tests/common.py
+++ b/printing_auto_base/tests/common.py
@@ -6,15 +6,14 @@ from unittest import mock
 
 from odoo.tests import common
 
-from odoo.addons.base_report_to_printer.models.printing_printer import PrintingPrinter
+PRINT_DOCUMENT = (
+    "odoo.addons.base_report_to_printer.models.printing_printer."
+    "PrintingPrinter.print_document"
+)
 
 
 def patch_print_document():
-    return mock.patch.object(PrintingPrinter, "print_document", print_document)
-
-
-def print_document(cls, *args, **kwargs):
-    return
+    return mock.patch(PRINT_DOCUMENT, mock.MagicMock())
 
 
 class TestPrintingAutoCommon(common.TransactionCase):

--- a/printing_auto_base/tests/test_printing_auto_base.py
+++ b/printing_auto_base/tests/test_printing_auto_base.py
@@ -99,13 +99,20 @@ class TestPrintingAutoBase(TestPrintingAutoCommon):
 
         printing_auto.printer_id = self.printer_1
         for nbr_of_copies in [0, 2, 1]:
+            self.printer_1.print_document.reset_mock()
             expected = (self.printer_1, nbr_of_copies)
             printing_auto.nbr_of_copies = nbr_of_copies
             self.assertEqual(expected, printing_auto.do_print(self.record))
+            # Check mock usage
+            kwargs = {"report": None, "content": self.data, "printer": self.printer_1}
+            expected_calls = [("__call__", (), kwargs)] * nbr_of_copies
+            self.assertEqual(self.printer_1.print_document.mock_calls, expected_calls)
 
         printing_auto.condition = "[('name', '=', 'test_printing_auto')]"
         expected = (self.printer_1, 0)
+        self.printer_1.print_document.reset_mock()
         self.assertEqual(expected, printing_auto.do_print(self.record))
+        self.printer_1.print_document.assert_not_called()
 
     def test_do_not_print_multiple_time_the_same_record(self):
         """Check the same record is not printed multiple times.


### PR DESCRIPTION
Having a Mock object is useful for writing tests