### PR TITLE
[16.0][FIX] base_report_to_printer: do not download text report sent to printer

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -35,11 +35,27 @@ class IrActionsReport(models.Model):
         string="Actions",
         help="This field allows configuring action and printer on a per " "user basis",
     )
+    is_report_to_printer_action = fields.Boolean(
+        compute="_compute_is_report_to_printer_action"
+    )
+
+    @api.depends("property_printing_action_id")
+    def _compute_is_report_to_printer_action(self):
+        for record in self:
+            record.is_report_to_printer_action = (
+                record.property_printing_action_id
+                and record.report_type in REPORT_TYPES
+            )
 
     @api.onchange("printing_printer_id")
     def onchange_printing_printer_id(self):
         """Reset the tray when the printer is changed"""
         self.printer_tray_id = False
+
+    def _get_readable_fields(self):
+        fields = super()._get_readable_fields()
+        fields.add("is_report_to_printer_action")
+        return fields
 
     @api.model
     def print_action_for_report_name(self, report_name):

--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -3,7 +3,7 @@ import {Markup} from "web.utils";
 import {registry} from "@web/core/registry";
 
 async function cupsReportActionHandler(action, options, env) {
-    if (action.report_type === "qweb-pdf") {
+    if (action.is_report_to_printer_action) {
         const orm = env.services.orm;
 
         const print_action = await orm.call(


### PR DESCRIPTION
In the case of a report of type "qweb-text" set to "Send to printer" (e.g. a zpl report), the pervious implementation was triggering a download of the report.

This is because inside the base odoo report handling function (odoo/addons/web/static/src/webclient/actions/action_service.js -> `_executeReportAction`), the code defaults to 'download' for text reports that have not been dealt with and current implementation only deals with "qweb-pdf" reports.
However, the supported types defined inside `REPORT_TYPES` are ["qweb-pdf", "qweb-text"].

Thus, the current approach now creates a new computed field `is_report_to_printer_action` (to replace the previous hard-coded solution) to deal with the logic of ensuring the report is of the expected type before triggering our custom action handler.