### PR TITLE
[18.0][FIX] report_print_send: messageIsHtml

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -51,7 +51,6 @@ async function cupsReportActionHandler(action, options, env) {
                     title: `${terms.issue_on} ${print_action.printer_name}`,
                     type: "warning",
                     sticky: true,
-                    messageIsHtml: true,
                     buttons: [
                         {
                             name: _t("Print"),


### PR DESCRIPTION
When attempting to print a report from a batch, this error message appears, stating that the attribute “messageIsHtml” cannot be found.

<img width="1584" height="939" alt="image" src="https://github.com/user-attachments/assets/6cca2a11-750f-415f-92f4-b18c4bbbb014" />

There is already a PR open, but it is inactive and has more changes than it should. Here is the link to the PR.

https://github.com/OCA/report-print-send/pull/409