### PR TITLE
[IMP] base_report_to_printer: Add a warning logger if printing has errors

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -5,12 +5,15 @@
 # Copyright (C) 2013-2014 Camptocamp (<http://www.camptocamp.com>)
 # Copyright 2024 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 import threading
 
 from odoo import _, api, exceptions, fields, models, registry
 from odoo.tools.safe_eval import safe_eval, time
 
 REPORT_TYPES = {"qweb-pdf": "pdf", "qweb-text": "text"}
+
+_logger = logging.getLogger(__name__)
 
 
 class IrActionsReport(models.Model):
@@ -143,7 +146,8 @@ class IrActionsReport(models.Model):
         else:
             try:
                 return self.print_document(record_ids, data=data)
-            except Exception:
+            except Exception as e:
+                _logger.warning("Unable to print document: %s", exc_info=e)
                 return
 
     def print_document_threaded(self, report_id, record_ids, data):

--- a/base_report_to_printer/tests/test_report.py
+++ b/base_report_to_printer/tests/test_report.py
@@ -100,6 +100,20 @@ class TestReport(common.HttpCase):
             }
         )
 
+    def test_print_document_action_exception_warning(self):
+        """Check the exception warning in logs"""
+        self.report.property_printing_action_id.action_type = "server"
+        self.report.printing_printer_id = self.new_printer()
+        with mock.patch(
+            "odoo.addons.base_report_to_printer.models."
+            "ir_actions_report.IrActionsReport."
+            "print_document"
+        ) as print_document:
+            print_document.side_effect = Exception("error")
+            with self.assertLogs(level="WARNING"):
+                self.report.print_document_client_action(self.partners.ids)
+            print_document.assert_called_once()
+
     def test_can_print_report_context_skip(self):
         """It should return False based on context"""
         rec_id = self.new_record().with_context(must_skip_send_to_printer=True)

--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -448,7 +448,7 @@ class PrintingLabelZpl2(models.Model):
     def _get_record(self):
         self.ensure_one()
         Obj = self.env[self.model_id.model]
-        record = Obj.search([("id", "=", self.record_id)], limit=1)
+        record = Obj.browse(self.record_id).exists()
         if not record:
             record = Obj.search([], limit=1, order="id desc")
         self.record_id = record.id

--- a/printer_zpl2/tests/test_test_mode.py
+++ b/printer_zpl2/tests/test_test_mode.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2018 Florent de Labarre (<https://github.com/fmdl>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import time
 from unittest.mock import patch
 
 from odoo.tests.common import TransactionCase
@@ -88,6 +89,7 @@ class TestWizardPrintRecordLabel(TransactionCase):
         self.label.labelary_width = 80
         self.label.labelary_height = 30
         self.label.labelary_dpmm = "8dpmm"
+        time.sleep(3)  # Avoid too fast execution that can cause issue with labelary api
         self.env["printing.label.zpl2.component"].create(
             {"name": "ZPL II Label", "label_id": self.label.id, "data": '"good_data"'}
         )


### PR DESCRIPTION

e.g.: in case of printing templates errors, the exception is trapped. Adding warnings in logs allows to help diagnoctics (and to catch them in external monitoring too).