### PR TITLE
[18.0][FW] [IMP] base_report_to_printer: Add a hook to get default printer for user

### DIFF
--- a/.oca/oca-port/blacklist/base_report_to_printer.json
+++ b/.oca/oca-port/blacklist/base_report_to_printer.json
@@ -1,5 +1,6 @@
 {
   "pull_requests": {
-    "242": "(auto) Nothing to port from PR #242"
+    "242": "(auto) Nothing to port from PR #242",
+    "OCA/report-print-send#352": "(auto) Nothing to port from PR #352"
   }
 }

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -64,12 +64,16 @@ class IrActionsReport(models.Model):
             serializable_result["action"] = "client"
         return serializable_result
 
+    def _get_user_default_printer(self, user):
+        return user.printing_printer_id
+
     def _get_user_default_print_behaviour(self):
         printer_obj = self.env["printing.printer"]
         user = self.env.user
+        printer = self._get_user_default_printer(user)
         return dict(
             action=user.printing_action or "client",
-            printer=user.printing_printer_id or printer_obj.get_default(),
+            printer=printer or printer_obj.get_default(),
             tray=(
                 str(user.printer_tray_id.system_name) if user.printer_tray_id else False
             ),


### PR DESCRIPTION
Port from 16.0 to 18.0:
- #412

The following PRs have been blacklisted:
- #352: (auto) Nothing to port from PR #352