### PR TITLE
[18.0][FIX] printing_auto_base: Fix record relation and filtering

### DIFF
--- a/printing_auto_base/models/printing_auto.py
+++ b/printing_auto_base/models/printing_auto.py
@@ -94,6 +94,7 @@ class PrintingAuto(models.Model):
 
     def _check_condition(self, record):
         domain = safe_eval(self.condition, {"env": self.env})
+        record = self._get_record(record)
         return record.filtered_domain(domain)
 
     def _get_content(self, records):
@@ -102,7 +103,6 @@ class PrintingAuto(models.Model):
         )
         content = []
         if generate_data_func:
-            records = self._get_record(records)
             for record in records:
                 content += generate_data_func(record)
         return content

--- a/printing_auto_base/tests/test_printing_auto_base.py
+++ b/printing_auto_base/tests/test_printing_auto_base.py
@@ -165,3 +165,28 @@ class TestPrintingAutoBase(TestPrintingAutoCommon):
             generate_data_from.assert_has_calls(
                 [mock.call(child1), mock.call(child2)], any_order=True
             )
+
+    def test_print_on_record_change(self):
+        vals = {
+            "record_change": "child_ids",
+            "printer_id": self.printer_1.id,
+            "condition": [("name", "=", "bob")],
+        }
+        printing_auto = self._create_printing_auto_report(vals=vals)
+        son = self.env["printingauto.tester.child"].create({"name": "bob"})
+        daughter = self.env["printingauto.tester.child"].create({"name": "cindy"})
+        daddy = self.env["printingauto.tester"].create(
+            {
+                "name": "john",
+                "child_ids": [(6, 0, (son | daughter).ids)],
+                "auto_printing_ids": [(4, printing_auto.id, 0)],
+            }
+        )
+        self.assertEqual(printing_auto._check_condition(daddy), son)
+        # Change child name, parent doesn't match anymore
+        son.name = "peter"
+        self.assertFalse(printing_auto._check_condition(daddy))
+        # Restore the name to bob, break the link
+        son.name = "bob"
+        daddy.child_ids = [(6, 0, daughter.ids)]
+        self.assertFalse(printing_auto._check_condition(daddy))


### PR DESCRIPTION
When applying the condition to filter out invalid records, it must be done on the related record defined in `record_change`, if any.