### PR TITLE
[18.0]FIX] base_report_to_printer: return a close action when the option is specified

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -24,6 +24,15 @@ async function cupsReportActionHandler(action, options, env) {
                 env.services.notification.add(_t("Successfully sent to printer!"), {
                     type: "success",
                 });
+                const {onClose} = options;
+                if (action.close_on_report_download) {
+                    return env.services.action.doAction(
+                        {type: "ir.actions.act_window_close"},
+                        {onClose}
+                    );
+                } else if (onClose) {
+                    onClose();
+                }
                 return true;
                 // In case of exception during the job, we won't get any response. So we
                 // should flag the exception and notify the user


### PR DESCRIPTION
Many modules can return the key `close_on_report_download` in the context. In the `web` module, this option is expected and handled accordingly. However, this module ignored the option, causing the wizard not to close when a report is generated from an action with target 'new' (typically a wizard). After this commit, the wizard closes correctly.

https://github.com/odoo/odoo/blob/401540aaa8e42243f4504c594d477330295ddee0/addons/web/static/src/webclient/actions/action_service.js#L1326-L1330

Example in the `delivery_package_number` module: https://github.com/OCA/delivery-carrier/blob/12e690c7b912073c2aa54be07868d84cbe24f438/delivery_package_number/wizard/stock_number_package_validate_wiz.py#L65

@Tecnativa @pedrobaeza @sergio-teruel  @CarlosRoca13  could you please review this?
