### PR TITLE
printer_zpl2: fix label._get_record method

### DIFF
--- a/printer_zpl2/models/printing_label_zpl2.py
+++ b/printer_zpl2/models/printing_label_zpl2.py
@@ -454,7 +454,7 @@ class PrintingLabelZpl2(models.Model):
     def _get_record(self):
         self.ensure_one()
         Obj = self.env[self.model_id.model]
-        record = Obj.search([("id", "=", self.record_id)], limit=1)
+        record = Obj.browse(self.record_id).exists()
         if not record:
             record = Obj.search([], limit=1, order="id desc")
         self.record_id = record.id


### PR DESCRIPTION
use model.browse() to check if the record exists.
model.search() by `id` doesn't work.