### PR TITLE
[18.0][FIX] base_report_to_printer: neutralization scripts

### DIFF
--- a/base_report_to_printer/data/neutralize.sql
+++ b/base_report_to_printer/data/neutralize.sql
@@ -1,2 +1,4 @@
 update printing_server set active=false;
 update printing_printer set active=false;
+update printing_report_xml_action set active=false;
+update ir_act_report_xml set printing_printer_id=null;

--- a/base_report_to_printer/models/printing_report_xml_action.py
+++ b/base_report_to_printer/models/printing_report_xml_action.py
@@ -37,6 +37,7 @@ class PrintingReportXmlAction(models.Model):
         string="Output Bin",
         domain="[('printer_id', '=', printer_id)]",
     )
+    active = fields.Boolean(default=True)
 
     @api.onchange("printer_id")
     def onchange_printer_id(self):

--- a/base_report_to_printer/views/ir_actions_report.xml
+++ b/base_report_to_printer/views/ir_actions_report.xml
@@ -20,9 +20,27 @@
                         />
                     </group>
                     <separator string="Specific actions per user" />
-                    <field name="printing_action_ids" />
+                    <field name="printing_action_ids">
+                        <list editable="bottom" decoration-muted="active == False">
+                            <field name="user_id" />
+                            <field name="action" />
+                            <field name="printer_id" />
+                            <field
+                                name="printer_input_tray_id"
+                                invisible="not printer_id"
+                            />
+                            <field
+                                name="printer_output_tray_id"
+                                invisible="not printer_id"
+                            />
+                            <field name="active" optional="hide" />
+                        </list>
+                    </field>
                 </page>
             </page>
         </field>
+    </record>
+    <record model="ir.actions.act_window" id="base.ir_action_report">
+        <field name="context">{'active_test': False}</field>
     </record>
 </odoo>


### PR DESCRIPTION
Even with odoo neutralize script executed reports where still being sent to printers.

On one side [the search for users behaviours](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L101) finds them even though the printers where deactivated, thus the need to a add an active field to this model and set it to false in the script.

On the other side the general printer configured in a report needs to be cleaned or [it will otherwise be found](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L87) and used for printing.