### PR TITLE
[16.0][FIX] base_report_to_printer: neutralization scripts

### DIFF
--- a/base_report_to_printer/data/neutralize.sql
+++ b/base_report_to_printer/data/neutralize.sql
@@ -1,2 +1,4 @@
 update printing_server set active=false;
 update printing_printer set active=false;
+update printing_report_xml_action set active=false;
+update ir_act_report_xml set printing_printer_id=null;

--- a/base_report_to_printer/models/printing_report_xml_action.py
+++ b/base_report_to_printer/models/printing_report_xml_action.py
@@ -32,6 +32,7 @@ class PrintingReportXmlAction(models.Model):
         string="Paper Source",
         domain="[('printer_id', '=', printer_id)]",
     )
+    active = fields.Boolean(default=True)
 
     @api.onchange("printer_id")
     def onchange_printer_id(self):


### PR DESCRIPTION
Even with odoo neutralize script executed reports where still being sent to printers.

On one side [the search for users behaviours](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L101) finds them even though the printers where deactivated, thus the need to a add an active field to this model and set it to false in the script.

On the other side the general printer configured in a report needs to be cleaned or [it will otherwise be found](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L87) and used for printing.



The second commits is for: 
    - The tests are designed to check the API response, but the problem is that two requests are made within a short time      interval. A mock would be appropriate if what was being checked was not the response from api.labelary. 
   
<img width="2215" height="194" alt="image" src="https://github.com/user-attachments/assets/8b3420a5-ad8d-4ec8-bd4e-3b465f4fbfc7" />
