### PR TITLE
[17.0][FIX] base_report_to_printer: Print ZPL without downloading

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -4,7 +4,7 @@ import {markup} from "@odoo/owl";
 import {registry} from "@web/core/registry";
 
 async function cupsReportActionHandler(action, options, env) {
-    if (action.report_type === "qweb-pdf") {
+    if (action.report_type === "qweb-pdf" || action.report_type === "qweb-text") {
         const orm = env.services.orm;
 
         const print_action = await orm.call(

--- a/printer_zpl2/tests/test_test_mode.py
+++ b/printer_zpl2/tests/test_test_mode.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018 Florent de Labarre (<https://github.com/fmdl>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import base64
+import time
 from unittest.mock import Mock, patch
 
 from odoo.tools import mute_logger
@@ -79,6 +80,7 @@ class TestWizardPrintRecordLabel(PrinterZpl2Common):
         self.label.labelary_width = 80
         self.label.labelary_height = 30
         self.label.labelary_dpmm = "8dpmm"
+        time.sleep(3)
         self.env["printing.label.zpl2.component"].create(
             {"name": "ZPL II Label", "label_id": self.label.id, "data": '"good_data"'}
         )


### PR DESCRIPTION
In a ZPL report, configured to print and with the default printer set, when printing it, in addition to sending it to the corresponding printer, it was downloaded to the device. With the change to pr, we eliminated the download to the device.