### PR TITLE
[18.0][FIX] base_report_to_printer: Print double label

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -3,7 +3,7 @@ import {markup} from "@odoo/owl";
 import {registry} from "@web/core/registry";
 
 async function cupsReportActionHandler(action, options, env) {
-    if (action.report_type === "qweb-pdf" || action.report_type === "qweb-text") {
+    if (action.report_type === "qweb-pdf") {
         const orm = env.services.orm;
 
         const print_action = await orm.call(


### PR DESCRIPTION
- These changes have been removed because we found several cases in which, instead of printing a single label, two labels were being printed. Removing the change means that only one label is printed again.