### PR TITLE
[16.0][BKP] report_print_send: backport from 18.0, fixed messageIsHtml

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -51,7 +51,6 @@ async function cupsReportActionHandler(action, options, env) {
                     title: `${terms.issue_on} ${print_action.printer_name}`,
                     type: "warning",
                     sticky: true,
-                    messageIsHtml: true,
                     buttons: [
                         {
                             name: env._t("Print"),


### PR DESCRIPTION
Backport to 16.0 from https://github.com/OCA/report-print-send/pull/418