### PR TITLE
[18.0] Revert "base_report_to_printer: Print ZXPL without downloading"

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -3,7 +3,7 @@ import {markup} from "@odoo/owl";
 import {registry} from "@web/core/registry";
 
 async function cupsReportActionHandler(action, options, env) {
-    if (action.report_type === "qweb-pdf" || action.report_type === "qweb-text") {
+    if (action.report_type === "qweb-pdf") {
         const orm = env.services.orm;
 
         const print_action = await orm.call(


### PR DESCRIPTION
This reverts commit 968036706a33188137416ead130e6f5e0b04061d from https://github.com/OCA/report-print-send/pull/442

