### PR TITLE
[19.0][FIX] base_report_to_printer

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -46,6 +46,7 @@ class PrintingPrinter(models.Model):
     model = fields.Char(readonly=True)
     location = fields.Char(readonly=True)
     uri = fields.Char(string="URI", readonly=True)
+    multi_thread = fields.Boolean()
 
     @staticmethod
     def _set_option_doc_format(report, value):


### PR DESCRIPTION
Add multi_thread field to avoid failure in ir_action_report.print_document_client_action, as the split in base_report_to_printer_cups left this behind.

@etobella 