### PR TITLE
[18.0][IMP] printer_zpl2: Migration script

### DIFF
--- a/printer_zpl2/migrations/18.0.1.0.0/pre-migration.py
+++ b/printer_zpl2/migrations/18.0.1.0.0/pre-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    view = env.ref(
+        "printer_zpl2.act_open_printing_label_zpl2_view_tree", raise_if_not_found=False
+    )
+    view.unlink()


### PR DESCRIPTION
Remove old action view, now in v18 the view name is changed to act_open_printing_label_zpl2_view_list from act_open_printing_label_zpl2_view_view, so we need remove old view

ping @carlos-lopez-tecnativa  @CarlosRoca13