### PR TITLE
[18.0][IMP] base_report_to_printer: Add 'backend' field to printer model

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -46,6 +46,11 @@ class PrintingPrinter(models.Model):
         help="Jobs printed on this printer.",
     )
     system_name = fields.Char(required=True, index=True)
+    backend = fields.Selection(
+        selection=[("cups", "Cups")],
+        required=True,
+        default="cups",
+    )
     default = fields.Boolean(readonly=True)
     status = fields.Selection(
         selection=[

--- a/base_report_to_printer/views/printing_printer.xml
+++ b/base_report_to_printer/views/printing_printer.xml
@@ -53,6 +53,7 @@
                     </div>
                     <group name="name">
                         <field name="system_name" />
+                        <field name="backend" />
                         <field name="server_id" />
                     </group>
                     <group col="4" colspan="4" name="default">


### PR DESCRIPTION
This allows extending the printer model to support multiple printing protocols beyond the current implementation as mentioned in https://github.com/OCA/report-print-send/pull/457#discussion_r3224309999

@DavidBForgeFlow @peluko00 @lbarry-apsl 