### PR TITLE
[19.0][FIX] base_report_to_printer: neutralization scripts

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -266,6 +266,9 @@ Contributors
 - Tris Doan <tridm@trobz.com>
 - Sergij Pfaifer <s.pfaifer@deinetuer.de>
 - Miquel Alzanillas <miquel.alzanillas@nagarro.com>
+- `Studio73 <https://studio73.es>`__:
+
+  - Eugenio Micó <eugenio@studio73.es>
 
 Other credits
 -------------

--- a/base_report_to_printer/readme/CONTRIBUTORS.md
+++ b/base_report_to_printer/readme/CONTRIBUTORS.md
@@ -18,3 +18,5 @@
 - Tris Doan \<<tridm@trobz.com>\>
 - Sergij Pfaifer \<<s.pfaifer@deinetuer.de>\>
 - Miquel Alzanillas  \<<miquel.alzanillas@nagarro.com>\>
+- [Studio73](https://studio73.es):
+  - Eugenio Micó \<<eugenio@studio73.es>\>

--- a/base_report_to_printer/static/description/index.html
+++ b/base_report_to_printer/static/description/index.html
@@ -602,6 +602,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 <li>Sergij Pfaifer &lt;<a class="reference external" href="mailto:s.pfaifer&#64;deinetuer.de">s.pfaifer&#64;deinetuer.de</a>&gt;</li>
 <li>Miquel Alzanillas &lt;<a class="reference external" href="mailto:miquel.alzanillas&#64;nagarro.com">miquel.alzanillas&#64;nagarro.com</a>&gt;</li>
+<li><a class="reference external" href="https://studio73.es">Studio73</a>:<ul>
+<li>Eugenio Micó &lt;<a class="reference external" href="mailto:eugenio&#64;studio73.es">eugenio&#64;studio73.es</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/base_report_to_printer/views/ir_actions_report.xml
+++ b/base_report_to_printer/views/ir_actions_report.xml
@@ -20,9 +20,27 @@
                         />
                     </group>
                     <separator string="Specific actions per user" />
-                    <field name="printing_action_ids" />
+                    <field name="printing_action_ids">
+                        <list editable="bottom" decoration-muted="not active">
+                            <field name="user_id" />
+                            <field name="action" />
+                            <field name="printer_id" />
+                            <field
+                                name="printer_input_tray_id"
+                                invisible="not printer_id"
+                            />
+                            <field
+                                name="printer_output_tray_id"
+                                invisible="not printer_id"
+                            />
+                            <field name="active" optional="hide" />
+                        </list>
+                    </field>
                 </page>
             </page>
         </field>
+    </record>
+    <record model="ir.actions.act_window" id="base.ir_action_report">
+        <field name="context">{'active_test': False}</field>
     </record>
 </odoo>


### PR DESCRIPTION

**fixes impemented in this v18.0 PR https://github.com/OCA/report-print-send/pull/433**

Even with odoo neutralize script executed reports where still being sent to printers.

On one side [the search for users behaviours](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L101) finds them even though the printers where deactivated, thus the need to a add an active field to this model and set it to false in the script.

On the other side the general printer configured in a report needs to be cleaned or [it will otherwise be found](https://github.com/OCA/report-print-send/blob/cb001b3f170f48e75848079f3afdaad3448898f4/base_report_to_printer/models/ir_actions_report.py#L87) and used for printing.