### PR TITLE
[17.0][FIX]base_report_to_printer: return a close action when the option is specified

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -25,6 +25,15 @@ async function cupsReportActionHandler(action, options, env) {
                 env.services.notification.add(_t("Successfully sent to printer!"), {
                     type: "success",
                 });
+                const {onClose} = options;
+                if (action.close_on_report_download) {
+                    env.services.action.doAction(
+                        {type: "ir.actions.act_window_close"},
+                        {onClose}
+                    );
+                } else if (onClose) {
+                    onClose();
+                }
                 return true;
                 // In case of exception during the job, we won't get any response. So we
                 // should flag the exception and notify the user


### PR DESCRIPTION
The changes from version 18 have been implemented, allowing you to close the wizard after printing