### PR TITLE
[19.0][FIX] base_report_to_printer: make action_type selection callable

### DIFF
--- a/base_report_to_printer/models/printing_action.py
+++ b/base_report_to_printer/models/printing_action.py
@@ -22,5 +22,7 @@ class PrintingAction(models.Model):
 
     name = fields.Char(required=True)
     action_type = fields.Selection(
-        selection=_available_action_types, string="Type", required=True
+        selection=lambda self: self._available_action_types,
+        string="Type",
+        required=True,
     )


### PR DESCRIPTION
The action_type Selection referenced the _available_action_types property object directly in the class body, so field.selection held a property instance. fields_get then raised 'TypeError: property object is not iterable' whenever the model was introspected (opening the view, Studio).

Wrap the property access in a lambda, like the two other selection fields of the module already do.