### PR TITLE
[18.0][FWD][IMP] Make 'server_id' mandatory only for CUPS printers

### DIFF
--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -12,7 +12,8 @@ import logging
 import os
 from tempfile import mkstemp
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -36,7 +37,6 @@ class PrintingPrinter(models.Model):
     server_id = fields.Many2one(
         comodel_name="printing.server",
         string="Server",
-        required=True,
         help="Server used to access this printer.",
     )
     job_ids = fields.One2many(
@@ -82,6 +82,14 @@ class PrintingPrinter(models.Model):
     multi_thread = fields.Boolean(
         compute="_compute_multi_thread", readonly=False, store=True
     )
+
+    @api.constrains("server_id", "backend")
+    def _check_server_id(self):
+        for printer in self:
+            if printer.backend == "cups" and not printer.server_id:
+                raise ValidationError(
+                    _("Server is required for printers using the Cups backend.")
+                )
 
     @api.depends("server_id.multi_thread")
     def _compute_multi_thread(self):

--- a/base_report_to_printer/views/printing_printer.xml
+++ b/base_report_to_printer/views/printing_printer.xml
@@ -54,7 +54,7 @@
                     <group name="name">
                         <field name="system_name" />
                         <field name="backend" />
-                        <field name="server_id" />
+                        <field name="server_id" required="backend=='cups'" />
                     </group>
                     <group col="4" colspan="4" name="default">
                         <field name="default" />


### PR DESCRIPTION
Forward port of https://github.com/OCA/report-print-send/pull/470

@cubells @bernatobrador