### PR TITLE
[18.0][FIX] base_report_to_printer: avoid double print of reports

### DIFF
--- a/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
+++ b/base_report_to_printer/static/src/js/qweb_action_manager.esm.js
@@ -24,19 +24,14 @@ async function cupsReportActionHandler(action, options, env) {
                 env.services.notification.add(_t("Successfully sent to printer!"), {
                     type: "success",
                 });
-                const {onClose} = options;
-                if (action.close_on_report_download) {
-                    return env.services.action.doAction(
-                        {type: "ir.actions.act_window_close"},
-                        {onClose}
-                    );
-                } else if (onClose) {
-                    onClose();
-                }
+                // Return a truthy value so the action manager considers the report
+                // handled. The action manager itself takes care of
+                // `close_on_report_download` and the `onClose` callback.
                 return true;
                 // In case of exception during the job, we won't get any response. So we
                 // should flag the exception and notify the user
             }
+
             env.services.notification.add(_t("Could not sent to printer!"), {
                 type: "danger",
             });


### PR DESCRIPTION
When a report is configured to print on a server-side printer and the action has close_on_report_download set (e.g. product label printing), the report was printed twice.

The client-side report action handler handled close_on_report_download itself and returned the result of the act_window_close action, which resolves to undefined. The action manager (_executeReportAction) then treated the report as not handled and fell back to downloading it via /report/download. That download re-rendered the qweb-pdf without the must_skip_send_to_printer context, so _render_qweb_pdf sent it to the printer a second time.

Return a truthy value from the handler instead and let the action manager take care of close_on_report_download and the onClose callback, which it already does for any truthy handler result.