### PR TITLE
[19.0][FIX] base_report_to_printer: Only search active printers

### DIFF
--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -118,6 +118,7 @@ class IrActionsReport(models.Model):
                 ("report_id", "=", self.id),
                 ("user_id", "=", self.env.uid),
                 ("action", "!=", "user_default"),
+                ("active", "=", True),
             ],
             limit=1,
         )


### PR DESCRIPTION
There were cases where printers that had been taken out of service would arrive.
