### PR TITLE
[19.0] [FIX] base_report_to_printer: restore the default printer hook 

### DIFF
--- a/base_report_to_label_printer/tests/test_ir_actions_report.py
+++ b/base_report_to_label_printer/tests/test_ir_actions_report.py
@@ -17,7 +17,7 @@ class TestIrActionsReport(TransactionCase):
         )
         self.report = self.Model.search([], limit=1)
 
-    def new_printer(self):
+    def new_printer(self, **vals):
         return self.env["printing.printer"].create(
             {
                 "name": "Printer",
@@ -28,6 +28,7 @@ class TestIrActionsReport(TransactionCase):
                 "model": "res.users",
                 "location": "Location",
                 "uri": "URI",
+                **vals,
             }
         )
 
@@ -35,7 +36,7 @@ class TestIrActionsReport(TransactionCase):
         """It should return the label printer from user"""
         self.report.label = True
         self.env.user.printing_action = "client"
-        self.env.user.default_label_printer_id = self.new_printer()
+        self.env.user.default_label_printer_id = self.new_printer(default=False)
         result = self.report.behaviour()
         self.assertEqual(
             result,
@@ -46,3 +47,13 @@ class TestIrActionsReport(TransactionCase):
                 "output_tray": False,
             },
         )
+
+    def test_print_behavior_user_printer_for_a_regular_report(self):
+        """It should return the user's own printer when the report is no label"""
+        self.report.label = False
+        self.env.user.printing_printer_id = self.new_printer()
+        self.env.user.default_label_printer_id = self.new_printer(
+            name="Label Printer", system_name="Label Sys Name", default=False
+        )
+        result = self.report.behaviour()
+        self.assertEqual(result["printer"], self.env.user.printing_printer_id)

--- a/base_report_to_printer/models/ir_actions_report.py
+++ b/base_report_to_printer/models/ir_actions_report.py
@@ -76,12 +76,23 @@ class IrActionsReport(models.Model):
             serializable_result["action"] = "client"
         return serializable_result
 
+    def _get_user_default_printer(self, user):
+        """Return the printer ``user`` prints this report on by default.
+
+        Hook for modules that route some reports to another printer, such as
+        ``base_report_to_label_printer`` sending labels to a label printer.
+        Returning an empty recordset leaves the caller to fall back on the
+        default printer.
+        """
+        return user.printing_printer_id
+
     def _get_user_default_print_behaviour(self):
         printer_obj = self.env["printing.printer"]
         user = self.env.user
+        printer = self._get_user_default_printer(user)
         return dict(
             action=user.printing_action or "client",
-            printer=user.printing_printer_id or printer_obj.get_default(),
+            printer=printer or printer_obj.get_default(),
             input_tray=str(user.printer_input_tray_id.system_name)
             if user.printer_input_tray_id
             else False,


### PR DESCRIPTION
This override didn't work since b75c6b0, where the hook that was originally introduced in a27fced got removed: 
- https://github.com/OCA/report-print-send/blob/77587409dcb852b702bdfb80e9ecc7d0b3d903f8/base_report_to_label_printer/models/ir_actions_report.py#L12-L15

It was not caught by tests