### PR TITLE
[19.0][FIX] base_report_to_printer: forward doc_format, and guard neutralize.sql

### DIFF
--- a/base_report_to_printer/README.rst
+++ b/base_report_to_printer/README.rst
@@ -164,34 +164,34 @@ Usage
 
 Guidelines for use:
 
-- To use a specific printing backend (e.g. CUPS), make sure the
-  corresponding module (such as ``base_report_to_printer_cups``) is
-  installed and configured.
-- To print a report on a specific printer or tray, you can configure
-  defaults in *Settings > Printing > Reports*.
-- To define user-specific behaviour, go to *Settings > Printing >
-  Reports* and configure *Specific actions per user*.
-- Each user can also select a default action, printer or tray in their
-  *Preferences*.
-- When no tray is configured for a report or a user, the default tray
-  defined by the printing backend (e.g. the CUPS server) will be used.
+-  To use a specific printing backend (e.g. CUPS), make sure the
+   corresponding module (such as ``base_report_to_printer_cups``) is
+   installed and configured.
+-  To print a report on a specific printer or tray, you can configure
+   defaults in *Settings > Printing > Reports*.
+-  To define user-specific behaviour, go to *Settings > Printing >
+   Reports* and configure *Specific actions per user*.
+-  Each user can also select a default action, printer or tray in their
+   *Preferences*.
+-  When no tray is configured for a report or a user, the default tray
+   defined by the printing backend (e.g. the CUPS server) will be used.
 
 Notes
 -----
 
-- This module (``base_report_to_printer``) only provides the **base
-  framework**.
-- To connect with a real print system, you must install an additional
-  backend module (e.g. ``base_report_to_printer_cups`` for CUPS).
-- Other backend modules can be developed to support different print
-  protocols or environments.
+-  This module (``base_report_to_printer``) only provides the **base
+   framework**.
+-  To connect with a real print system, you must install an additional
+   backend module (e.g. ``base_report_to_printer_cups`` for CUPS).
+-  Other backend modules can be developed to support different print
+   protocols or environments.
 
 Known issues / Roadmap
 ======================
 
-- With threaded printing there's no download fallback when the issue
-  isn't detected by the CUPS Odoo backend. To able to do it, we would
-  need to notify the bus or use web_notify for it.
+-  With threaded printing there's no download fallback when the issue
+   isn't detected by the CUPS Odoo backend. To able to do it, we would
+   need to notify the bus or use web_notify for it.
 
 Changelog
 =========
@@ -199,26 +199,26 @@ Changelog
 19.0.1.0.0 (2025-12-18)
 -----------------------
 
-- [REF] Extracted all CUPS-specific functionality into a dedicated
-  module: ``base_report_to_printer_cups``.
-- [ADD] Introduced a base abstraction layer for report-to-printer, to
-  allow adding new backends (protocols) without modifying the core
-  module.
-- [IMP] Improved configuration instructions (global, per-user,
-  per-report, and per user+report).
-- [CLEAN] Updated documentation and module description to reflect new
-  architecture.
-- 
+-  [REF] Extracted all CUPS-specific functionality into a dedicated
+   module: ``base_report_to_printer_cups``.
+-  [ADD] Introduced a base abstraction layer for report-to-printer, to
+   allow adding new backends (protocols) without modifying the core
+   module.
+-  [IMP] Improved configuration instructions (global, per-user,
+   per-report, and per user+report).
+-  [CLEAN] Updated documentation and module description to reflect new
+   architecture.
+-  
 
 13.0.1.0.0 (2019-09-30)
 -----------------------
 
-- [RELEASE] Port from V12.
+-  [RELEASE] Port from V12.
 
 12.0.1.0.0 (2018-02-04)
 -----------------------
 
-- [RELEASE] Port from V11.
+-  [RELEASE] Port from V11.
 
 Bug Tracker
 ===========
@@ -246,29 +246,33 @@ Authors
 Contributors
 ------------
 
-- Ferran Pegueroles <ferran@pegueroles.com>
-- Albert Cervera i Areny <albert@nan-tic.com>
-- Davide Corio <davide.corio@agilebg.com>
-- Lorenzo Battistini <lorenzo.battistini@agilebg.com>
-- Yannick Vaucher <yannick.vaucher@camptocamp.com>
-- Lionel Sausin <ls@numerigraphe.com>
-- Guewen Baconnier <guewen.baconnier@camptocamp.com>
-- Dave Lasley <dave@laslabs.com>
-- Sylvain Garancher <sylvain.garancher@syleam.fr>
-- Jairo Llopis <jairo.llopis@tecnativa.com>
-- Graeme Gellatly <graeme@o4sb.com>
-- Rod Schouteden <rod@schout-it.be>
-- Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
-- Matias Peralta <mnp@adhoc.com.ar>
-- Hughes Damry <hughes.damry@acsone.eu>
-- Akim Juillerat <akim.juillerat@camptocamp.com>
-- Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
-- Tris Doan <tridm@trobz.com>
-- Sergij Pfaifer <s.pfaifer@deinetuer.de>
-- Miquel Alzanillas <miquel.alzanillas@nagarro.com>
-- `Studio73 <https://studio73.es>`__:
+-  Ferran Pegueroles <ferran@pegueroles.com>
+-  Albert Cervera i Areny <albert@nan-tic.com>
+-  Davide Corio <davide.corio@agilebg.com>
+-  Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+-  Yannick Vaucher <yannick.vaucher@camptocamp.com>
+-  Lionel Sausin <ls@numerigraphe.com>
+-  Guewen Baconnier <guewen.baconnier@camptocamp.com>
+-  Dave Lasley <dave@laslabs.com>
+-  Sylvain Garancher <sylvain.garancher@syleam.fr>
+-  Jairo Llopis <jairo.llopis@tecnativa.com>
+-  Graeme Gellatly <graeme@o4sb.com>
+-  Rod Schouteden <rod@schout-it.be>
+-  Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+-  Matias Peralta <mnp@adhoc.com.ar>
+-  Hughes Damry <hughes.damry@acsone.eu>
+-  Akim Juillerat <akim.juillerat@camptocamp.com>
+-  Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+-  Tris Doan <tridm@trobz.com>
+-  Sergij Pfaifer <s.pfaifer@deinetuer.de>
+-  Miquel Alzanillas <miquel.alzanillas@nagarro.com>
+-  `Studio73 <https://studio73.es>`__:
 
-  - Eugenio Micó <eugenio@studio73.es>
+   -  Eugenio Micó <eugenio@studio73.es>
+
+-  `STeSI Consulting <https://stesi.consulting>`__:
+
+   -  Michele Di Croce <dicroce.m@stesi.consulting>
 
 Other credits
 -------------

--- a/base_report_to_printer/data/neutralize.sql
+++ b/base_report_to_printer/data/neutralize.sql
@@ -1,3 +1,16 @@
+-- The `active` column of printing_report_xml_action is missing on a database
+-- upgraded from an earlier version, since the module adds it only once it is
+-- updated. Neutralization runs before that, on the restored dump, so an
+-- unguarded UPDATE raises "column active does not exist" and aborts the build.
 update printing_printer set active=false;
-update printing_report_xml_action set active=false;
 update ir_act_report_xml set printing_printer_id=null;
+do $$
+begin
+    if exists (
+        select 1 from information_schema.columns
+         where table_name = 'printing_report_xml_action'
+           and column_name = 'active'
+    ) then
+        update printing_report_xml_action set active=false;
+    end if;
+end $$;

--- a/base_report_to_printer/models/printing_printer.py
+++ b/base_report_to_printer/models/printing_printer.py
@@ -91,7 +91,11 @@ class PrintingPrinter(models.Model):
         finally:
             os.close(fd)
         try:
-            self.print_file(file_name, report=report, **kwargs)
+            # doc_format has to reach the backend: `_set_option_doc_format`
+            # turns "raw" into the CUPS option that sends the file through
+            # unfiltered. Held back in the signature, a ZPL label arrived as a
+            # plain file and the queue driver printed its source as text.
+            self.print_file(file_name, report=report, doc_format=doc_format, **kwargs)
         except Exception as e:
             raise exceptions.UserError(
                 self.env._("Failed to print document: %(error)s", error=e)

--- a/base_report_to_printer/readme/CONTRIBUTORS.md
+++ b/base_report_to_printer/readme/CONTRIBUTORS.md
@@ -20,3 +20,5 @@
 - Miquel Alzanillas  \<<miquel.alzanillas@nagarro.com>\>
 - [Studio73](https://studio73.es):
   - Eugenio Micó \<<eugenio@studio73.es>\>
+- [STeSI Consulting](https://stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>

--- a/base_report_to_printer/static/description/index.html
+++ b/base_report_to_printer/static/description/index.html
@@ -606,6 +606,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Eugenio Micó &lt;<a class="reference external" href="mailto:eugenio&#64;studio73.es">eugenio&#64;studio73.es</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://stesi.consulting">STeSI Consulting</a>:<ul>
+<li>Michele Di Croce &lt;<a class="reference external" href="mailto:dicroce.m&#64;stesi.consulting">dicroce.m&#64;stesi.consulting</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/base_report_to_printer/tests/test_printing_printer.py
+++ b/base_report_to_printer/tests/test_printing_printer.py
@@ -54,6 +54,21 @@ class TestPrintingPrinterBase(TransactionCase):
         )
         self.assertIn("InputSlot", self.Model.print_options(report, input_tray="Test"))
 
+    def test_print_document_forwards_doc_format(self):
+        """print_document passes the format on, so raw jobs stay raw."""
+        printer = self.new_record()
+        captured = {}
+
+        def capture(self, file_name, report=None, **print_opts):
+            captured["opts"] = print_opts
+            captured["options"] = self.print_options(report=report, **print_opts)
+            return True
+
+        self.patch(type(printer), "print_file", capture)
+        printer.print_document(None, b"^XA^XZ", doc_format="raw")
+        self.assertEqual(captured["opts"], {"doc_format": "raw"})
+        self.assertEqual(captured["options"], {"raw": "True"})
+
     def test_set_default_and_unset(self):
         printer = self.new_record()
         self.assertTrue(printer.default)


### PR DESCRIPTION
## print_document drops doc_format

`print_document` takes `doc_format` as a named argument and forwards only `**kwargs`, so the value never reaches `print_file`, `print_options` or `_set_option_doc_format`. A caller asking for a raw job gets a job with no options at all.

`printer_zpl2` prints that way:

    printer.print_document(report=None, content=label_contents, doc_format="raw")

Without the raw option CUPS hands the file to the queue driver. On a Zebra queue carrying a ZPL PPD the driver renders the ZPL as text, so the label comes out as a page of `^XA^FO...` commands instead of the label itself.

Measured on a 19.0 database with `print_file` instrumented:

| | kwargs reaching print_file | CUPS options |
|---|---|---|
| 16.0 | `{'doc_format': 'raw'}` | `{'raw': 'True'}` |
| 19.0 before this branch | `{}` | `{}` |

The 16.0 signature was `print_document(self, report, content, **print_opts)`, so the format travelled inside `print_opts`. The refactor that extracted the CUPS backend, b75c6b0, turned it into a parameter and left the forwarding
behind. 
A test pins it: `print_document(..., doc_format="raw")` reaches `print_file`
and resolves to `{'raw': 'True'}`.

## neutralize.sql aborts when the active column is missing

Neutralization runs on the restored dump, before the modules update, so a database upgraded from an earlier version has no `active` column on `printing_report_xml_action` yet: the module adds it on its own update. The
statement then raises

    ERROR: column "active" of relation "printing_report_xml_action" does not exist

and the build stops with the printers left enabled, the opposite of what neutralization is for.

The update now runs inside a `DO` block that reads `information_schema.columns` first. Checked both ways on a 19.0 database: with the column the three statements apply, without it the guarded one is skipped and nothing raises.

issue: https://github.com/OCA/report-print-send/issues/479